### PR TITLE
Modify stonith action retrieval and improve test coverage 

### DIFF
--- a/src/module_utils/get_cluster_status.py
+++ b/src/module_utils/get_cluster_status.py
@@ -48,16 +48,20 @@ class BaseClusterStatusChecker(SapAutomationQA):
         """
         Retrieves the stonith action from the system.
         """
+        self.result["stonith_action"] = "unknown"
         try:
             stonith_action = self.execute_command_subprocess(STONITH_ACTION[self.ansible_os_family])
-            stonith_action = (
-                stonith_action.split("stonith-action:")[-1]
-                if self.ansible_os_family == "REDHAT"
-                else stonith_action
-            )
-            self.result["stonith_action"] = stonith_action.strip()
-        except Exception:
-            self.result["stonith_action"] = "reboot"
+            actions = [
+                "reboot",
+                "poweroff",
+                "off",
+            ]
+            for action in actions:
+                if action in stonith_action:
+                    self.result["stonith_action"] = action
+                    break
+        except Exception as ex:
+            self.log(logging.WARNING, f"Failed to get stonith action: {str(ex)}")
 
     def _validate_cluster_basic_status(self, cluster_status_xml: ET.Element):
         """


### PR DESCRIPTION
# Description
This pull request includes changes to improve the handling of the STONITH (Shoot The Other Node In The Head) action retrieval and its associated tests. The main changes involve modifying the logic for determining the STONITH action and updating the corresponding tests to ensure proper functionality.

Improvements to STONITH action retrieval:

* [`src/module_utils/get_cluster_status.py`](diffhunk://#diff-78bff49ef14c2e1f7aec67bdd022341ff0a5abc3964d79d498edbcd4482d2132R51-R64): Modified the `_get_stonith_action` method to initialize the `stonith_action` to "unknown" and updated the logic to check for specific actions ("reboot", "poweroff", "off") within the command output. Added logging for exceptions.

Updates to tests:

* [`tests/module_utils/get_cluster_status_test.py`](diffhunk://#diff-154da8c792eba55365d15d459e2b17214151bda6a1a3865f8ede1e8beb286b7dL69-R69): Renamed the `test_get_stonith_action` method to `test_get_stonith_action_rhel94` and added a new `test_get_stonith_action` method to handle different return values. Updated the tests to assert the correct `stonith_action` based on the command output. 

### Problem Statement
In RHEL94, we found that the STONITH action retrieval logic was not handling certain command output correctly, leading to incorrect action determination.
Until RHEL92 the command output had ":", from RHEL94, the command output now includes "=".

## Solution Details
- [x] Implementation changes
- [ ] Configuration updates
- [ ] Documentation updates

- OS: RHEL 9.4
- Database Type: HANA

### Test Cases

- [x] Unit tests added/updated
- [ ] Manual Testing done

### Checklist
- [x] Code follows project style guidelines
- [ ] Documentation has been updated
- [x] Tests are passing
- [x] PR title follows conventional commit format
- [ ] Breaking changes are clearly marked
