### PR TITLE
Update timeout configurations for ANF and AFS in resource defaults

### DIFF
--- a/src/roles/ha_scs/tasks/files/constants.yaml
+++ b/src/roles/ha_scs/tasks/files/constants.yaml
@@ -105,7 +105,9 @@ RESOURCE_DEFAULTS:
       operations:
         monitor:
           interval:                       ["11", "11s"]
-          timeout:                        ["105", "105s"]
+          timeout:
+            ANF:                          ["105", "105s"]
+            AFS:                          ["60", "60s"]
         start:
           interval:                       ["0", "0s"]
           timeout:                        ["180", "180s"]
@@ -130,7 +132,9 @@ RESOURCE_DEFAULTS:
       operations:
         monitor:
           interval:                       ["11", "11s"]
-          timeout:                        ["105", "105s"]
+          timeout:
+            ANF:                          ["105", "105s"]
+            AFS:                          ["60", "60s"]
         start:
           interval:                       ["0", "0s"]
           timeout:                        ["180", "180s"]

--- a/src/vars/input-api.yaml
+++ b/src/vars/input-api.yaml
@@ -20,14 +20,14 @@ test_groups:
           The HA parameter validation test validates HA configuration,
           including Corosync settings, Pacemaker resources, SBD device configuration,
           and HANA system replication setup.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       Azure Load Balancer Validation
         task_name:                  azure-lb
         description: |
           The Azure LB configuration test validates Azure Load Balancer setup including health probe
           configuration, backend pool settings, load balancing rules, and frontend IP configuration.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Resource Migration
         task_name:                  resource-migration
@@ -37,7 +37,7 @@ test_groups:
           resources to the secondary node, verifies proper role changes, ensures cluster maintains
           stability throughout the transition, and validates complete data synchronization after
           migration.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Primary Node Crash
         task_name:                  primary-node-crash
@@ -46,7 +46,7 @@ test_groups:
           crashes on the primary node. It simulates an index server failure by forcefully terminating
           the process, then verifies automatic failover to the secondary node, monitors system
           replication status, and confirms service recovery without data loss.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Block Network Communication
         task_name:                  block-network
@@ -56,7 +56,7 @@ test_groups:
           It verifies split-brain prevention mechanisms, validates proper failover execution when nodes
           become isolated, and ensures cluster stability and data consistency after network
           sconnectivity is restored.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Crash index server on primary node
         task_name:                  primary-crash-index
@@ -66,7 +66,7 @@ test_groups:
           service failure, triggering automatic failover to the secondary node. The test verifies
           proper failover execution, ensures data consistency, and validates service restoration after
           recovery.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Primary Node Kill
         task_name:                  primary-node-kill
@@ -75,7 +75,7 @@ test_groups:
           processes on the primary node using SIGKILL signal. This simulates an abrupt service failure,
           triggering automatic failover to the secondary node. The test verifies proper promotion of
           secondary to primary, ensures data consistency, and validates complete cluster recovery.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Echo B on Primary Node
         task_name:                  primary-echo-b
@@ -84,7 +84,7 @@ test_groups:
           executing the 'echo b' command to trigger an abrupt reboot without proper shutdown. This
           tests the cluster's ability to handle unexpected primary node failures, validates proper
           failover execution, and verifies data consistency after recovery.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Secondary Node Kill
         task_name:                  secondary-node-kill
@@ -93,7 +93,7 @@ test_groups:
           processes on the secondary node using the kill -9 signal. The test validates that the primary
           node maintains normal operation while the secondary node undergoes recovery, ensuring cluster
           stability and proper data synchronization after the recovery process completes.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Echo B on Secondary Node
         task_name:                  secondary-echo-b
@@ -102,7 +102,7 @@ test_groups:
           by executing the 'echo b' command, triggering an immediate reboot without proper shutdown
           procedures. The test validates that the primary node maintains operation, verifies cluster
           stability, and ensures system replication resumes correctly after the secondary node recovers.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Freeze File System on Primary Node
         task_name:                  fs-freeze
@@ -111,7 +111,7 @@ test_groups:
           becomes unresponsive. It simulates a storage issue by freezing the filesystem on the primary
           node running HANA database, which triggers automatic failover to the secondary node. The test
           verifies proper cluster reaction, resource migration, and data consistency after recovery.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Test SBD Inquisitor kill
         task_name:                  sbd-fencing
@@ -119,7 +119,7 @@ test_groups:
           Validates cluster fencing mechanism by killing the SBD inquisitor process on the primary
           node. Tests proper fence detection, node isolation, and automated failover to ensure cluster
           integrity during hardware or communication failures.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       HA Functional Test- Crash index server on secondary node
         task_name:                  secondary-crash-index
@@ -128,7 +128,7 @@ test_groups:
           the secondary node. It validates that the primary node continues normal operation while
           verifying the cluster's ability to handle secondary failures, tests automatic recovery
           mechanisms, and ensures system replication resumes properly after service restoration.
-        enabled:                    false
+        enabled:                    true
 
   - name:                           HA_SCS
     test_cases:
@@ -145,7 +145,7 @@ test_groups:
         description: |
           The Azure LB configuration test validates Azure Load Balancer setup including health probe
           configuration, backend pool settings, load balancing rules, and frontend IP configuration.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "SAPControl Config Validation"
         task_name:                  sapcontrol-config
@@ -154,14 +154,14 @@ test_groups:
           SCS configuration. It executes commands like HAGetFailoverConfig,
           HACheckFailoverConfig, and HACheckConfig, capturing their outputs and statuses to
           ensure proper configuration and functionality.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "Manual ASCS Migration"
         task_name:                  ascs-migration
         description: |
           The Resource Migration test validates planned failover scenarios by controlling resource
           movement between SCS nodes, ensuring proper role changes.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "ASCS Node Crash"
         task_name:                  ascs-node-crash
@@ -170,7 +170,7 @@ test_groups:
           simulates an ASCS node failure by forcefully terminating the process, then verifies
           automatic failover to the ERS node, monitors system replication status, and confirms
           service recovery.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "Block Network Communication"
         task_name:                  block-network
@@ -180,7 +180,7 @@ test_groups:
           verifies split-brain prevention mechanisms, validates proper failover execution when
           nodes become isolated, and ensures cluster stability after network connectivity is
           restored.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "Kill Message Server Process"
         task_name:                  kill-message-server
@@ -189,7 +189,7 @@ test_groups:
           the ASCS node by forcefully terminating it using the kill -9 signal. It verifies proper
           cluster reaction, automatic failover to the ERS node, and ensures service continuity
           after the process failure.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "Kill Enqueue Server Process"
         task_name:                  kill-enqueue-server
@@ -197,7 +197,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "Kill Enqueue Replication Server Process"
         task_name:                  kill-enqueue-replication
@@ -205,7 +205,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "Kill sapstartsrv Process for ASCS"
         task_name:                  kill-sapstartsrv-process
@@ -213,7 +213,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "Manual Restart of ASCS Instance"
         task_name:                  manual-restart
@@ -221,7 +221,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    false
+        enabled:                    true
 
       - name:                       "HAFailoverToNode Test"
         task_name:                  ha-failover-to-node
@@ -229,7 +229,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    false
+        enabled:                    true
 
 
 # Default values for HANA DB HA Test Cases

--- a/src/vars/input-api.yaml
+++ b/src/vars/input-api.yaml
@@ -20,14 +20,14 @@ test_groups:
           The HA parameter validation test validates HA configuration,
           including Corosync settings, Pacemaker resources, SBD device configuration,
           and HANA system replication setup.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       Azure Load Balancer Validation
         task_name:                  azure-lb
         description: |
           The Azure LB configuration test validates Azure Load Balancer setup including health probe
           configuration, backend pool settings, load balancing rules, and frontend IP configuration.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Resource Migration
         task_name:                  resource-migration
@@ -37,7 +37,7 @@ test_groups:
           resources to the secondary node, verifies proper role changes, ensures cluster maintains
           stability throughout the transition, and validates complete data synchronization after
           migration.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Primary Node Crash
         task_name:                  primary-node-crash
@@ -46,7 +46,7 @@ test_groups:
           crashes on the primary node. It simulates an index server failure by forcefully terminating
           the process, then verifies automatic failover to the secondary node, monitors system
           replication status, and confirms service recovery without data loss.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Block Network Communication
         task_name:                  block-network
@@ -56,7 +56,7 @@ test_groups:
           It verifies split-brain prevention mechanisms, validates proper failover execution when nodes
           become isolated, and ensures cluster stability and data consistency after network
           sconnectivity is restored.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Crash index server on primary node
         task_name:                  primary-crash-index
@@ -66,7 +66,7 @@ test_groups:
           service failure, triggering automatic failover to the secondary node. The test verifies
           proper failover execution, ensures data consistency, and validates service restoration after
           recovery.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Primary Node Kill
         task_name:                  primary-node-kill
@@ -75,7 +75,7 @@ test_groups:
           processes on the primary node using SIGKILL signal. This simulates an abrupt service failure,
           triggering automatic failover to the secondary node. The test verifies proper promotion of
           secondary to primary, ensures data consistency, and validates complete cluster recovery.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Echo B on Primary Node
         task_name:                  primary-echo-b
@@ -84,7 +84,7 @@ test_groups:
           executing the 'echo b' command to trigger an abrupt reboot without proper shutdown. This
           tests the cluster's ability to handle unexpected primary node failures, validates proper
           failover execution, and verifies data consistency after recovery.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Secondary Node Kill
         task_name:                  secondary-node-kill
@@ -93,7 +93,7 @@ test_groups:
           processes on the secondary node using the kill -9 signal. The test validates that the primary
           node maintains normal operation while the secondary node undergoes recovery, ensuring cluster
           stability and proper data synchronization after the recovery process completes.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Echo B on Secondary Node
         task_name:                  secondary-echo-b
@@ -102,7 +102,7 @@ test_groups:
           by executing the 'echo b' command, triggering an immediate reboot without proper shutdown
           procedures. The test validates that the primary node maintains operation, verifies cluster
           stability, and ensures system replication resumes correctly after the secondary node recovers.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Freeze File System on Primary Node
         task_name:                  fs-freeze
@@ -111,7 +111,7 @@ test_groups:
           becomes unresponsive. It simulates a storage issue by freezing the filesystem on the primary
           node running HANA database, which triggers automatic failover to the secondary node. The test
           verifies proper cluster reaction, resource migration, and data consistency after recovery.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Test SBD Inquisitor kill
         task_name:                  sbd-fencing
@@ -119,7 +119,7 @@ test_groups:
           Validates cluster fencing mechanism by killing the SBD inquisitor process on the primary
           node. Tests proper fence detection, node isolation, and automated failover to ensure cluster
           integrity during hardware or communication failures.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       HA Functional Test- Crash index server on secondary node
         task_name:                  secondary-crash-index
@@ -128,7 +128,7 @@ test_groups:
           the secondary node. It validates that the primary node continues normal operation while
           verifying the cluster's ability to handle secondary failures, tests automatic recovery
           mechanisms, and ensures system replication resumes properly after service restoration.
-        enabled:                    true
+        enabled:                    false
 
   - name:                           HA_SCS
     test_cases:
@@ -145,7 +145,7 @@ test_groups:
         description: |
           The Azure LB configuration test validates Azure Load Balancer setup including health probe
           configuration, backend pool settings, load balancing rules, and frontend IP configuration.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "SAPControl Config Validation"
         task_name:                  sapcontrol-config
@@ -154,14 +154,14 @@ test_groups:
           SCS configuration. It executes commands like HAGetFailoverConfig,
           HACheckFailoverConfig, and HACheckConfig, capturing their outputs and statuses to
           ensure proper configuration and functionality.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "Manual ASCS Migration"
         task_name:                  ascs-migration
         description: |
           The Resource Migration test validates planned failover scenarios by controlling resource
           movement between SCS nodes, ensuring proper role changes.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "ASCS Node Crash"
         task_name:                  ascs-node-crash
@@ -170,7 +170,7 @@ test_groups:
           simulates an ASCS node failure by forcefully terminating the process, then verifies
           automatic failover to the ERS node, monitors system replication status, and confirms
           service recovery.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "Block Network Communication"
         task_name:                  block-network
@@ -180,7 +180,7 @@ test_groups:
           verifies split-brain prevention mechanisms, validates proper failover execution when
           nodes become isolated, and ensures cluster stability after network connectivity is
           restored.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "Kill Message Server Process"
         task_name:                  kill-message-server
@@ -189,7 +189,7 @@ test_groups:
           the ASCS node by forcefully terminating it using the kill -9 signal. It verifies proper
           cluster reaction, automatic failover to the ERS node, and ensures service continuity
           after the process failure.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "Kill Enqueue Server Process"
         task_name:                  kill-enqueue-server
@@ -197,7 +197,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "Kill Enqueue Replication Server Process"
         task_name:                  kill-enqueue-replication
@@ -205,7 +205,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "Kill sapstartsrv Process for ASCS"
         task_name:                  kill-sapstartsrv-process
@@ -213,7 +213,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "Manual Restart of ASCS Instance"
         task_name:                  manual-restart
@@ -221,7 +221,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    true
+        enabled:                    false
 
       - name:                       "HAFailoverToNode Test"
         task_name:                  ha-failover-to-node
@@ -229,7 +229,7 @@ test_groups:
           The Enqueue Server Process Kill test simulates failure of the enqueue server process on
           the ASCS node by forcefully terminating it using the kill -9 signal. It validates proper
           cluster behavior, automatic failover execution.
-        enabled:                    true
+        enabled:                    false
 
 
 # Default values for HANA DB HA Test Cases


### PR DESCRIPTION
This pull request updates the `RESOURCE_DEFAULTS` configuration in the `constants.yaml` file to introduce resource-specific timeout values for operations. The changes primarily focus on differentiating timeout settings for `ANF` and `AFS` resources.

### Updates to resource operation timeouts:

* [`src/roles/ha_scs/tasks/files/constants.yaml`](diffhunk://#diff-9468267d6716aa3f4daa87223fa1cbc39313abd068ab270111d0a815eede5781L108-R110): Modified the `timeout` field under `operations.monitor` to specify distinct timeout values for `ANF` (["105", "105s"]) and `AFS` (["60", "60s"]) resources. Previously, a single timeout value was applied universally. [[1]](diffhunk://#diff-9468267d6716aa3f4daa87223fa1cbc39313abd068ab270111d0a815eede5781L108-R110) [[2]](diffhunk://#diff-9468267d6716aa3f4daa87223fa1cbc39313abd068ab270111d0a815eede5781L133-R137)