### PR TITLE
Refactor the conditional logic for task retrieving saphanasr_angi

### DIFF
--- a/src/roles/ha_db_hana/tasks/resource-migration.yml
+++ b/src/roles/ha_db_hana/tasks/resource-migration.yml
@@ -32,9 +32,9 @@
             test_execution_hostname:    "{{ hostvars[cluster_status_pre.primary_node].ansible_hostname }}"
 
         - name:                         "Test Execution: Get HANA resource id for saphanasr_angi"
+          when:                         saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR-angi"
           block:
             - name:                     "Test Execution: Get HANA resource id for saphanasr_angi"
-              when:                     saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR-angi"
               ansible.builtin.shell: >-
                                         set -o pipefail && {{ commands
                                           | selectattr('name','equalto','get_hana_resource_id_saphanasr_angi')


### PR DESCRIPTION
This pull request includes a minor change to the `src/roles/ha_db_hana/tasks/resource-migration.yml` file. The change refactors the conditional logic for determining when to execute the block that retrieves the HANA resource ID for `saphanasr_angi`.

* [`src/roles/ha_db_hana/tasks/resource-migration.yml`](diffhunk://#diff-95869082ca144c705faf7bb538a741d6c5ed541a1fc8dcb11fa1b34c27e8792bR35-L37): Moved the `when` condition for the block to the task level for better readability and organization.