### PR TITLE
Add hana_resource_name parameter to HANA tasks to get hana resource name dynamically

### DIFF
--- a/src/modules/get_cluster_status_db.py
+++ b/src/modules/get_cluster_status_db.py
@@ -208,8 +208,8 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
             },
             HanaSRProvider.ANGI: {
                 "clone_attr": f"hana_{self.database_sid}_clone_state",
-                "sync_attr": f"master-{self.hana_resource_name}"
-                or f"master-rsc_SAPHanaCon_{self.database_sid.upper()}"
+                "sync_attr": f"master-{self.hana_resource_name}" if self.hana_resource_name
+                else f"master-rsc_SAPHanaCon_{self.database_sid.upper()}"
                 + f"_HDB{self.db_instance_number}",
                 "primary": {"clone": "PROMOTED", "sync": "150"},
                 "secondary": {"clone": "DEMOTED", "sync": "100"},

--- a/src/modules/get_cluster_status_db.py
+++ b/src/modules/get_cluster_status_db.py
@@ -146,11 +146,13 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
         db_instance_number: str,
         saphanasr_provider: HanaSRProvider,
         ansible_os_family: OperatingSystemFamily,
+        hana_resource_name: str = "",
     ):
         super().__init__(ansible_os_family)
         self.database_sid = database_sid
         self.saphanasr_provider = saphanasr_provider
         self.db_instance_number = db_instance_number
+        self.hana_resource_name = hana_resource_name
         self.result.update(
             {
                 "primary_node": "",
@@ -206,7 +208,8 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
             },
             HanaSRProvider.ANGI: {
                 "clone_attr": f"hana_{self.database_sid}_clone_state",
-                "sync_attr": f"master-rsc_SAPHanaCon_{self.database_sid.upper()}"
+                "sync_attr": f"master-{self.hana_resource_name}"
+                or f"master-rsc_SAPHanaCon_{self.database_sid.upper()}"
                 + f"_HDB{self.db_instance_number}",
                 "primary": {"clone": "PROMOTED", "sync": "150"},
                 "secondary": {"clone": "DEMOTED", "sync": "100"},
@@ -288,6 +291,7 @@ def run_module() -> None:
         database_sid=dict(type="str", required=True),
         saphanasr_provider=dict(type="str", required=True),
         db_instance_number=dict(type="str", required=True),
+        hana_resource_name=dict(type="str", required=False),
         filter=dict(type="str", required=False, default="os_family"),
     )
 
@@ -300,6 +304,7 @@ def run_module() -> None:
             str(ansible_facts(module).get("os_family", "UNKNOWN")).upper()
         ),
         db_instance_number=module.params["db_instance_number"],
+        hana_resource_name=module.params.get("hana_resource_name", ""),
     )
     checker.run()
 

--- a/src/modules/get_cluster_status_db.py
+++ b/src/modules/get_cluster_status_db.py
@@ -208,9 +208,12 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
             },
             HanaSRProvider.ANGI: {
                 "clone_attr": f"hana_{self.database_sid}_clone_state",
-                "sync_attr": f"master-{self.hana_resource_name}" if self.hana_resource_name
-                else f"master-rsc_SAPHanaCon_{self.database_sid.upper()}"
-                + f"_HDB{self.db_instance_number}",
+                "sync_attr": (
+                    f"master-{self.hana_resource_name}"
+                    if self.hana_resource_name
+                    else f"master-rsc_SAPHanaCon_{self.database_sid.upper()}"
+                    + f"_HDB{self.db_instance_number}"
+                ),
                 "primary": {"clone": "PROMOTED", "sync": "150"},
                 "secondary": {"clone": "DEMOTED", "sync": "100"},
             },

--- a/src/roles/ha_db_hana/tasks/block-network.yml
+++ b/src/roles/ha_db_hana/tasks/block-network.yml
@@ -93,6 +93,7 @@
             operation_step:                 "test_execution"
             database_sid:                   "{{ db_sid | lower }}"
             saphanasr_provider:             "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:             "{{ hana_resource_name | default('') }}"
           register:                         cluster_status_test_execution_primary
           retries:                          "{{ default_retries }}"
           delay:                            "{{ default_delay }}"
@@ -119,6 +120,7 @@
             operation_step:                 "test_execution"
             database_sid:                   "{{ db_sid | lower }}"
             saphanasr_provider:             "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:             "{{ hana_resource_name | default('') }}"
           register:                         cluster_status_post_primary
           retries:                          "{{ default_retries }}"
           delay:                            "{{ default_delay }}"
@@ -138,6 +140,7 @@
             operation_step:                 "test_execution"
             database_sid:                   "{{ db_sid | lower }}"
             saphanasr_provider:             "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:             "{{ hana_resource_name | default('') }}"
           register:                         cluster_status_test_execution_secondary
           retries:                          "{{ default_retries }}"
           delay:                            "{{ default_delay }}"
@@ -155,6 +158,7 @@
             operation_step:                 "test_execution"
             database_sid:                   "{{ db_sid | lower }}"
             saphanasr_provider:             "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:             "{{ hana_resource_name | default('') }}"
           register:                         cluster_status_post_secondary
           retries:                          "{{ default_retries }}"
           delay:                            "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/fs-freeze.yml
+++ b/src/roles/ha_db_hana/tasks/fs-freeze.yml
@@ -59,6 +59,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -75,6 +76,7 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/primary-crash-index.yml
+++ b/src/roles/ha_db_hana/tasks/primary-crash-index.yml
@@ -57,6 +57,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -71,6 +72,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -116,10 +118,11 @@
 
         - name:                         "Test Execution: Validate HANA DB cluster status 2"
           get_cluster_status_db:
-            db_instance_number:             "{{ db_instance_number }}"
+            db_instance_number:         "{{ db_instance_number }}"
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/primary-echo-b.yml
+++ b/src/roles/ha_db_hana/tasks/primary-echo-b.yml
@@ -49,6 +49,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
           register:                     cluster_status_test_execution
@@ -63,6 +64,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
           register:                     cluster_status_test_execution
@@ -108,6 +110,7 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/primary-node-crash.yml
+++ b/src/roles/ha_db_hana/tasks/primary-node-crash.yml
@@ -45,6 +45,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -88,6 +89,7 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/primary-node-kill.yml
+++ b/src/roles/ha_db_hana/tasks/primary-node-kill.yml
@@ -46,6 +46,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -62,6 +63,7 @@
                 operation_step:         "test_execution"
                 database_sid:           "{{ db_sid | lower }}"
                 saphanasr_provider:     "{{ saphanasr_provider | default('SAPHanaSR') }}"
+                hana_resource_name:     "{{ hana_resource_name | default('') }}"
               register:                 cluster_status_test_execution
               retries:                  "{{ default_retries }}"
               delay:                    "{{ default_delay }}"
@@ -106,6 +108,7 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/resource-migration.yml
+++ b/src/roles/ha_db_hana/tasks/resource-migration.yml
@@ -104,6 +104,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -159,6 +160,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution_1
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/sbd-fencing.yml
+++ b/src/roles/ha_db_hana/tasks/sbd-fencing.yml
@@ -60,6 +60,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
           register:                     cluster_status_test_execution
@@ -76,6 +77,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/secondary-crash-index.yml
+++ b/src/roles/ha_db_hana/tasks/secondary-crash-index.yml
@@ -57,6 +57,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -70,6 +71,7 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/secondary-echo-b.yml
+++ b/src/roles/ha_db_hana/tasks/secondary-echo-b.yml
@@ -53,6 +53,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
           register:                     cluster_status_test_execution
@@ -66,6 +67,7 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/secondary-node-kill.yml
+++ b/src/roles/ha_db_hana/tasks/secondary-node-kill.yml
@@ -51,6 +51,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -64,6 +65,7 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+            hana_resource_name:         "{{ hana_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/misc/tasks/cluster-report.yml
+++ b/src/roles/misc/tasks/cluster-report.yml
@@ -12,6 +12,7 @@
     operation_step:                     "cluster_report_collection"
     database_sid:                       "{{ db_sid | lower | default('') }}"
     saphanasr_provider:                 "{{ saphanasr_provider | default('SAPHanaSR') }}"
+    hana_resource_name:                 "{{ hana_resource_name | default('') }}"
   register:                             cluster_status
   failed_when:                          cluster_status.primary_node == ""
 

--- a/src/roles/misc/tasks/pre-validations-db.yml
+++ b/src/roles/misc/tasks/pre-validations-db.yml
@@ -18,6 +18,66 @@
       when:                         (ansible_os_family | upper) == "SUSE"
       ansible.builtin.include_tasks: "roles/misc/tasks/get-saphanasr-provider.yml"
 
+    - name:                         "Pre validation: Get HANA resource id for saphanasr_angi"
+      when:                         saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR-angi"
+      block:
+        - name:                     "Pre validation: Get HANA resource id for saphanasr_angi"
+          ansible.builtin.shell: >-
+                                    set -o pipefail && {{ commands
+                                      | selectattr('name','equalto','get_hana_resource_id_saphanasr_angi')
+                                      | map(attribute=(ansible_os_family|upper))
+                                      | first
+                                    }}
+          args:
+            executable:             /bin/bash
+          changed_when:             false
+          register:                 hana_resource_id
+          failed_when:              hana_resource_id.rc != 0
+
+        - name:                     "Pre validation: Set fact the hana_resource_name"
+          ansible.builtin.set_fact:
+            hana_resource_name:     "{{ hana_resource_id.stdout }}"
+
+    - name:                         "Pre validation: Get HANA resource id"
+      when:                         saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR"
+      block:
+        - name:                     "Try master resource ID"
+          ansible.builtin.shell: >-
+                                    set -o pipefail && {{ commands
+                                      | selectattr('name','equalto','get_hana_resource_id')
+                                      | map(attribute=(ansible_os_family|upper))
+                                      | first
+                                    }}
+          args:
+            executable:             /bin/bash
+          changed_when:             false
+          register:                 hana_resource_id
+          failed_when:              hana_resource_id.rc != 0
+      rescue:
+        - name:                     "Try clone resource ID"
+          ansible.builtin.shell: >-
+                                    set -o pipefail && {{ commands
+                                      | selectattr('name','equalto','get_hana_resource_id')
+                                      | map(attribute='REDHAT')
+                                      | first
+                                    }}
+          args:
+            executable:             /bin/bash
+          changed_when:             false
+          register:                 hana_resource_id
+          failed_when:              hana_resource_id.rc != 0
+          ignore_errors:            true
+      always:
+        - name:                     "Test Execution: Set the resource name"
+          when:
+                                    - hana_resource_id.rc == 0
+                                    - hana_resource_id.stdout is defined
+                                    - hana_resource_id.stdout | type_debug != 'NoneType'
+                                    - hana_resource_id.stdout | trim | length > 1
+          ansible.builtin.set_fact:
+            hana_resource_name:     "{{ hana_resource_id.stdout }}"
+
+
     - name:                         "Pre Validation: Validate HANA DB cluster status on primary node"
       become:                       true
       get_cluster_status_db:
@@ -25,10 +85,10 @@
         operation_step:             "pre_failover"
         database_sid:               "{{ db_sid | lower }}"
         saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
+        hana_resource_name:         "{{ hana_resource_name | default('') }}"
       register:                     cluster_status_pre
       until:                        cluster_status_pre.primary_node != "" or
                                     cluster_status_pre.secondary_node != ""
-      timeout:                      5
       retries:                      3
 
     - name:                         "Pre Validation: CleanUp any failed resource"

--- a/src/roles/misc/tasks/pre-validations-db.yml
+++ b/src/roles/misc/tasks/pre-validations-db.yml
@@ -22,6 +22,7 @@
       when:                         saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR-angi"
       block:
         - name:                     "Pre validation: Get HANA resource id for saphanasr_angi"
+          become:                   true
           ansible.builtin.shell: >-
                                     set -o pipefail && {{ commands
                                       | selectattr('name','equalto','get_hana_resource_id_saphanasr_angi')
@@ -42,6 +43,7 @@
       when:                         saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR"
       block:
         - name:                     "Try master resource ID"
+          become:                   true
           ansible.builtin.shell: >-
                                     set -o pipefail && {{ commands
                                       | selectattr('name','equalto','get_hana_resource_id')
@@ -55,6 +57,7 @@
           failed_when:              hana_resource_id.rc != 0
       rescue:
         - name:                     "Try clone resource ID"
+          become:                   true
           ansible.builtin.shell: >-
                                     set -o pipefail && {{ commands
                                       | selectattr('name','equalto','get_hana_resource_id')

--- a/tests/modules/get_cluster_status_db_test.py
+++ b/tests/modules/get_cluster_status_db_test.py
@@ -32,6 +32,7 @@ class TestHanaClusterStatusChecker:
             ansible_os_family=OperatingSystemFamily.REDHAT,
             saphanasr_provider=HanaSRProvider.SAPHANASR,
             db_instance_number="00",
+            hana_resource_name="rsc_SAPHanaCon_TEST_HDB00",
         )
 
     @pytest.fixture
@@ -47,6 +48,7 @@ class TestHanaClusterStatusChecker:
             ansible_os_family=OperatingSystemFamily.SUSE,
             saphanasr_provider=HanaSRProvider.ANGI,
             db_instance_number="00",
+            hana_resource_name="rsc_SAPHanaCon_TEST_HDB00",
         )
 
     def test_get_automation_register(self, mocker, hana_checker_classic):

--- a/tests/roles/ha_db_hana/block_network_test.py
+++ b/tests/roles/ha_db_hana/block_network_test.py
@@ -32,6 +32,17 @@ class TestBlockNetworkTest(RolesTestingBaseDB):
         :type: str
         """
 
+        commands = [
+            {
+                "name": "get_hana_resource_id",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+            {
+                "name": "get_hana_resource_id_saphanasr_angi",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+        ]
+
         task_counter_file = "/tmp/get_cluster_status_counter_block-network"
         if os.path.exists(task_counter_file):
             os.remove(task_counter_file)
@@ -51,6 +62,7 @@ class TestBlockNetworkTest(RolesTestingBaseDB):
             "bin/nc",
             "bin/echo",
             "bin/sleep",
+            "bin/cibadmin",
             "bin/SAPHanaSR-manageProvider",
         ]
 
@@ -65,6 +77,7 @@ class TestBlockNetworkTest(RolesTestingBaseDB):
                 "NFS_provider": "ANF",
                 "database_cluster_type": "ISCSI",
                 "sap_port_to_ping": "1128",
+                "commands": commands,
             },
         )
 

--- a/tests/roles/ha_db_hana/primary_node_ops_test.py
+++ b/tests/roles/ha_db_hana/primary_node_ops_test.py
@@ -98,6 +98,17 @@ class TestDbHDBOperations(RolesTestingBaseDB):
         :ytype: str
         """
 
+        commands = [
+            {
+                "name": "get_hana_resource_id",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+            {
+                "name": "get_hana_resource_id_saphanasr_angi",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+        ]
+
         task_counter_file = f"/tmp/get_cluster_status_counter_{task_type['task_name']}"
         if os.path.exists(task_counter_file):
             os.remove(task_counter_file)
@@ -113,6 +124,7 @@ class TestDbHDBOperations(RolesTestingBaseDB):
             "bin/crm",
             "bin/echo",
             "bin/killall",
+            "bin/cibadmin",
             "bin/SAPHanaSR-manageProvider",
         ]
 
@@ -129,6 +141,7 @@ class TestDbHDBOperations(RolesTestingBaseDB):
                 "node_tier": "hana",
                 "NFS_provider": "ANF",
                 "database_cluster_type": "ISCSI",
+                "commands": commands,
             },
         )
 

--- a/tests/roles/ha_db_hana/secondary_node_ops_test.py
+++ b/tests/roles/ha_db_hana/secondary_node_ops_test.py
@@ -69,6 +69,17 @@ class TestDbSecondaryHDBOperations(RolesTestingBaseDB):
         :ytype: str
         """
 
+        commands = [
+            {
+                "name": "get_hana_resource_id",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+            {
+                "name": "get_hana_resource_id_saphanasr_angi",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+        ]
+
         task_counter_file = f"/tmp/get_cluster_status_counter_{task_type['task_name']}"
         if os.path.exists(task_counter_file):
             os.remove(task_counter_file)
@@ -87,9 +98,10 @@ class TestDbSecondaryHDBOperations(RolesTestingBaseDB):
                 "bin/crm_resource",
                 "bin/echo",
                 "bin/killall",
+                "bin/cibadmin",
                 "bin/SAPHanaSR-manageProvider",
             ],
-            extra_vars_override={"node_tier": "hana"},
+            extra_vars_override={"node_tier": "hana", "commands": commands},
         )
 
         os.makedirs(f"{temp_dir}/bin", exist_ok=True)

--- a/tests/roles/mock_data/get_cluster_status_db.txt
+++ b/tests/roles/mock_data/get_cluster_status_db.txt
@@ -11,6 +11,7 @@ def main():
             database_sid=dict(type="str", required=True),
             saphanasr_provider=dict(type="str", required=True),
             db_instance_number=dict(type="str", required=True),
+            hana_resource_name=dict(type="str", default="")
         )
     )
 

--- a/tests/roles/mock_data/secondary_get_cluster_status_db.txt
+++ b/tests/roles/mock_data/secondary_get_cluster_status_db.txt
@@ -10,7 +10,8 @@ def main():
             operation_step=dict(type="str", required=True),
             database_sid=dict(type="str", required=True),
             saphanasr_provider=dict(type="str", required=True),
-            db_instance_number=dict(type="str", required=True)
+            db_instance_number=dict(type="str", required=True),
+            hana_resource_name=dict(type="str", default="")
         )
     )
 


### PR DESCRIPTION
This pull request introduces support for a new optional parameter, `hana_resource_name`, across multiple modules and roles in the codebase. The changes enhance flexibility in handling HANA resource names and improve compatibility with various configurations. The most important changes include updates to the `get_cluster_status_db.py` module and modifications to task files within the `ha_db_hana` role to incorporate the new parameter.

### Updates to `get_cluster_status_db.py`:

* Added a new optional parameter, `hana_resource_name`, to the `__init__` method and updated the `result` dictionary to include this parameter. (`src/modules/get_cluster_status_db.py`)
* Modified the `_process_node_attributes` method to dynamically use `hana_resource_name` for constructing synchronization attributes, with a fallback to the default format. (`src/modules/get_cluster_status_db.py`)
* Updated the `run_module` function to accept `hana_resource_name` as an optional parameter and pass it to the `checker.run()` method. (`src/modules/get_cluster_status_db.py`) [[1]](diffhunk://#diff-d0f5b8b712bff563ba0387aa11086b766ab00ff5059be92059476e8f9a4b8439R294) [[2]](diffhunk://#diff-d0f5b8b712bff563ba0387aa11086b766ab00ff5059be92059476e8f9a4b8439R307)

### Updates to `ha_db_hana` role task files:

* Incorporated the `hana_resource_name` parameter into various task files (e.g., `block-network.yml`, `fs-freeze.yml`, `primary-crash-index.yml`, and others) to support its usage during task execution. (`src/roles/ha_db_hana/tasks`) [[1]](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3R96) [[2]](diffhunk://#diff-81aa6c21cc2087674cdc2fde958484d4e2f1e188ecc9cce00a909e5420779363R62) [[3]](diffhunk://#diff-2e872e645177f9ab6c6b26f3e1c9f0218898692a4327b6e18d6509dc00d8eaa1R60) [[4]](diffhunk://#diff-100df1aafaaa1f5433ba12cb090c23eb971c8cf809cad619286fbf417f68c158R52) [[5]](diffhunk://#diff-8044cd1bd5051fd0786b9df98b5edccaafff7045d7f57fbe11bbd4c042d90227R48) [[6]](diffhunk://#diff-b5d075a97cb9479c92f9f6c781777d97cf2f0723945d1ac101542f2aa97144e3R49) [[7]](diffhunk://#diff-95869082ca144c705faf7bb538a741d6c5ed541a1fc8dcb11fa1b34c27e8792bR107) [[8]](diffhunk://#diff-a3ce10a3c5107bcec5bf77ea45e9448f09735dce4d8792b612f9c2aff1833162R63) [[9]](diffhunk://#diff-85ade724d3b31aec8f0c3d7b2d7846037868c053dc4cab2b2e53f01da7419f1dR60) [[10]](diffhunk://#diff-470176a59734cbe0d34cbd827f73b01b5caea62d1a9240aa58b817ebf4dba003R56)
* Ensured the parameter is passed with a default value of an empty string if not explicitly provided, maintaining backward compatibility. (`src/roles/ha_db_hana/tasks`) [[1]](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3R123) [[2]](diffhunk://#diff-81aa6c21cc2087674cdc2fde958484d4e2f1e188ecc9cce00a909e5420779363R79) [[3]](diffhunk://#diff-2e872e645177f9ab6c6b26f3e1c9f0218898692a4327b6e18d6509dc00d8eaa1R75) [[4]](diffhunk://#diff-100df1aafaaa1f5433ba12cb090c23eb971c8cf809cad619286fbf417f68c158R67) [[5]](diffhunk://#diff-8044cd1bd5051fd0786b9df98b5edccaafff7045d7f57fbe11bbd4c042d90227R92) [[6]](diffhunk://#diff-b5d075a97cb9479c92f9f6c781777d97cf2f0723945d1ac101542f2aa97144e3R66) [[7]](diffhunk://#diff-95869082ca144c705faf7bb538a741d6c5ed541a1fc8dcb11fa1b34c27e8792bR163) [[8]](diffhunk://#diff-a3ce10a3c5107bcec5bf77ea45e9448f09735dce4d8792b612f9c2aff1833162R80) [[9]](diffhunk://#diff-85ade724d3b31aec8f0c3d7b2d7846037868c053dc4cab2b2e53f01da7419f1dR74) [[10]](diffhunk://#diff-470176a59734cbe0d34cbd827f73b01b5caea62d1a9240aa58b817ebf4dba003R70)