### PR TITLE
Add a rescue operation to handle network-related failures

### DIFF
--- a/docs/HIGH_AVAILABILITY.md
+++ b/docs/HIGH_AVAILABILITY.md
@@ -245,7 +245,7 @@ Here is an example of the sap-parameters.yaml file format:
 ```yaml
 # The SAP and Database SID of the SAP system.
 sap_sid: "your-sap-sid"
-db_sid: "your-db-sid"
+database_sid: "your-db-sid"
 
 # Boolean indicating if the SCS and database is configured as highly available.
 scs_high_availability: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   referencing
 azure-common==1.1.28
     # via azure-mgmt-network
-azure-core==1.34.0
+azure-core==1.35.0
     # via
     #   azure-identity
     #   azure-kusto-data
@@ -40,7 +40,7 @@ azure-kusto-data==5.0.4
     #   azure-kusto-ingest
 azure-kusto-ingest==5.0.4
     # via -r requirements.in
-azure-mgmt-core==1.5.0
+azure-mgmt-core==1.6.0
     # via azure-mgmt-network
 azure-mgmt-network==29.0.0
     # via -r requirements.in
@@ -58,7 +58,7 @@ black==25.1.0
     #   ansible-lint
 bracex==2.6
     # via wcmatch
-certifi==2025.6.15
+certifi==2025.7.9
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -68,11 +68,11 @@ click==8.2.1
     # via
     #   -r requirements.in
     #   black
-coverage[toml]==7.9.1
+coverage[toml]==7.9.2
     # via
     #   -r requirements.in
     #   pytest-cov
-cryptography==45.0.4
+cryptography==45.0.5
     # via
     #   ansible-core
     #   azure-identity
@@ -144,7 +144,7 @@ packaging==25.0
     #   ansible-runner
     #   black
     #   pytest
-pandas==2.3.0
+pandas==2.3.1
     # via -r requirements.in
 pathspec==0.12.1
     # via
@@ -241,7 +241,7 @@ tomli==2.2.1
     #   pytest
 tomlkit==0.13.3
     # via pylint
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   astroid
     #   azure-core

--- a/src/roles/ha_db_hana/tasks/block-network.yml
+++ b/src/roles/ha_db_hana/tasks/block-network.yml
@@ -203,6 +203,17 @@
       ansible.builtin.include_tasks:        "roles/misc/tasks/post-validations.yml"
 
   rescue:
+    - name:                                 "Test Execution Failure: Remove the firewall rule on primary node."
+      become:                               true
+      ansible.builtin.shell: |
+                                            iptables -D INPUT -s {{ secondary_node_ip }} -j DROP;
+                                            iptables -D OUTPUT -d {{ secondary_node_ip }} -j DROP
+      register:                             firewall_rule_deleted
+      changed_when:                         firewall_rule_deleted.rc == 0
+      failed_when:                          firewall_rule_deleted.rc != 0
+      when:                                 ansible_hostname == cluster_status_pre.primary_node and
+                                            secondary_node_ip is defined
+
     - name:                                 "Rescue operation"
       ansible.builtin.include_tasks:        "roles/misc/tasks/rescue.yml"
 


### PR DESCRIPTION
This pull request includes changes to improve naming consistency in configuration files and add a rescue operation to handle network-related failures in high availability setups.

### Improvements to naming consistency:
* [`docs/HIGH_AVAILABILITY.md`](diffhunk://#diff-debb0f1bb405a5e75b36b7f8a753db6ffd2e47f90a6176fcfb2826876de95b3aL248-R248): Renamed `db_sid` to `database_sid` in the example `sap-parameters.yaml` file to align with naming conventions.

### Enhancements to high availability setup:
* [`src/roles/ha_db_hana/tasks/block-network.yml`](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3R206-R216): Added a rescue task to remove firewall rules on the primary node in case of test execution failure, ensuring proper cleanup and recovery during high availability network tests.