### PR TITLE
Updated commands to get the automated-register and priority fencing delay

### DIFF
--- a/src/module_utils/commands.py
+++ b/src/module_utils/commands.py
@@ -30,11 +30,20 @@ STONITH_ACTION = {
     OperatingSystemFamily.SUSE: ["crm", "configure", "get_property", "stonith-action"],
 }
 
-CIBADMIN_COMMAND = lambda parameter: [
-    "cibadmin",
-    "--query",
-    "--xpath",
-    "//nvpair[@name='" + parameter + "']",
+AUTOMATED_REGISTER = lambda rsc: [
+    "crm_resource",
+    "--resource",
+    rsc,
+    "--get-parameter=AUTOMATED_REGISTER",
+]
+
+PRIORITY_FENCING_DELAY = [
+    "crm_attribute",
+    "--type",
+    "crm_config",
+    "--name",
+    "priority-fencing-delay",
+    "--quiet",
 ]
 
 FREEZE_FILESYSTEM = lambda file_system, mount_point: [

--- a/src/module_utils/commands.py
+++ b/src/module_utils/commands.py
@@ -30,13 +30,12 @@ STONITH_ACTION = {
     OperatingSystemFamily.SUSE: ["crm", "configure", "get_property", "stonith-action"],
 }
 
-AUTOMATED_REGISTER = [
+CIBADMIN_COMMAND = lambda parameter: [
     "cibadmin",
     "--query",
     "--xpath",
-    "//nvpair[@name='AUTOMATED_REGISTER']",
+    "//nvpair[@name='" + parameter + "']",
 ]
-
 
 FREEZE_FILESYSTEM = lambda file_system, mount_point: [
     "mount",

--- a/src/modules/get_cluster_status_db.py
+++ b/src/modules/get_cluster_status_db.py
@@ -167,12 +167,16 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
             }
         )
 
-    def _get_cluster_pramaeters(self) -> None:
+    def _get_cluster_parameters(self) -> None:
         """
         Retrieves the value of the AUTOMATED_REGISTER attribute.
         """
         param_commands = {
-            "AUTOMATED_REGISTER": AUTOMATED_REGISTER(self.hana_primitive_resource_name),
+            "AUTOMATED_REGISTER": (
+                AUTOMATED_REGISTER(self.hana_primitive_resource_name)
+                if self.hana_primitive_resource_name
+                else AUTOMATED_REGISTER(self.hana_clone_resource_name)
+            ),
             "PRIORITY_FENCING_DELAY": PRIORITY_FENCING_DELAY,
         }
 
@@ -289,7 +293,7 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
         :rtype: Dict[str, str]
         """
         result = super().run()
-        self._get_cluster_pramaeters()
+        self._get_cluster_parameters()
         return result
 
 

--- a/src/modules/get_cluster_status_db.py
+++ b/src/modules/get_cluster_status_db.py
@@ -146,13 +146,15 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
         db_instance_number: str,
         saphanasr_provider: HanaSRProvider,
         ansible_os_family: OperatingSystemFamily,
-        hana_resource_name: str = "",
+        hana_clone_resource_name: str = "",
+        hana_primitive_resource_name: str = "",
     ):
         super().__init__(ansible_os_family)
         self.database_sid = database_sid
         self.saphanasr_provider = saphanasr_provider
         self.db_instance_number = db_instance_number
-        self.hana_resource_name = hana_resource_name
+        self.hana_clone_resource_name = hana_clone_resource_name
+        self.hana_primitive_resource_name = hana_primitive_resource_name
         self.result.update(
             {
                 "primary_node": "",
@@ -170,7 +172,7 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
         Retrieves the value of the AUTOMATED_REGISTER attribute.
         """
         param_commands = {
-            "AUTOMATED_REGISTER": AUTOMATED_REGISTER(self.hana_resource_name),
+            "AUTOMATED_REGISTER": AUTOMATED_REGISTER(self.hana_primitive_resource_name),
             "PRIORITY_FENCING_DELAY": PRIORITY_FENCING_DELAY,
         }
 
@@ -216,8 +218,8 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
             HanaSRProvider.ANGI: {
                 "clone_attr": f"hana_{self.database_sid}_clone_state",
                 "sync_attr": (
-                    f"master-{self.hana_resource_name}"
-                    if self.hana_resource_name
+                    f"master-{self.hana_clone_resource_name}"
+                    if self.hana_clone_resource_name
                     else f"master-rsc_SAPHanaCon_{self.database_sid.upper()}"
                     + f"_HDB{self.db_instance_number}"
                 ),
@@ -301,7 +303,8 @@ def run_module() -> None:
         database_sid=dict(type="str", required=True),
         saphanasr_provider=dict(type="str", required=True),
         db_instance_number=dict(type="str", required=True),
-        hana_resource_name=dict(type="str", required=False),
+        hana_clone_resource_name=dict(type="str", required=False),
+        hana_primitive_resource_name=dict(type="str", required=False),
         filter=dict(type="str", required=False, default="os_family"),
     )
 
@@ -314,7 +317,8 @@ def run_module() -> None:
             str(ansible_facts(module).get("os_family", "UNKNOWN")).upper()
         ),
         db_instance_number=module.params["db_instance_number"],
-        hana_resource_name=module.params.get("hana_resource_name", ""),
+        hana_clone_resource_name=module.params.get("hana_clone_resource_name", ""),
+        hana_primitive_resource_name=module.params.get("hana_primitive_resource_name", ""),
     )
     checker.run()
 

--- a/src/modules/get_cluster_status_db.py
+++ b/src/modules/get_cluster_status_db.py
@@ -169,7 +169,7 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
 
     def _get_cluster_parameters(self) -> None:
         """
-        Retrieves the value of the AUTOMATED_REGISTER attribute.
+        Retrieves the values of the AUTOMATED_REGISTER and PRIORITY_FENCING_DELAY attributes.
         """
         param_commands = {
             "AUTOMATED_REGISTER": (

--- a/src/modules/get_cluster_status_db.py
+++ b/src/modules/get_cluster_status_db.py
@@ -14,10 +14,10 @@ from ansible.module_utils.facts.compat import ansible_facts
 try:
     from ansible.module_utils.get_cluster_status import BaseClusterStatusChecker
     from ansible.module_utils.enums import OperatingSystemFamily, HanaSRProvider
-    from ansible.module_utils.commands import CIBADMIN_COMMAND
+    from ansible.module_utils.commands import AUTOMATED_REGISTER, PRIORITY_FENCING_DELAY
 except ImportError:
     from src.module_utils.get_cluster_status import BaseClusterStatusChecker
-    from src.module_utils.commands import CIBADMIN_COMMAND
+    from src.module_utils.commands import AUTOMATED_REGISTER, PRIORITY_FENCING_DELAY
     from src.module_utils.enums import OperatingSystemFamily, HanaSRProvider
 
 
@@ -169,12 +169,17 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
         """
         Retrieves the value of the AUTOMATED_REGISTER attribute.
         """
-        for parameter in ["AUTOMATED_REGISTER", "priority-fencing-delay"]:
+        param_commands = {
+            "AUTOMATED_REGISTER": AUTOMATED_REGISTER(self.hana_resource_name),
+            "PRIORITY_FENCING_DELAY": PRIORITY_FENCING_DELAY,
+        }
+
+        for param_name, command in param_commands.items():
             try:
-                cmd_output = self.execute_command_subprocess(CIBADMIN_COMMAND(parameter)).strip()
-                self.result[parameter] = ET.fromstring(cmd_output).get("value")
+                cmd_output = self.execute_command_subprocess(command).strip()
+                self.result[param_name] = ET.fromstring(cmd_output).get("value")
             except Exception:
-                self.result[parameter] = "unknown"
+                self.result[param_name] = "unknown"
 
     def _process_node_attributes(self, cluster_status_xml: ET.Element) -> Dict[str, Any]:
         """

--- a/src/modules/get_cluster_status_db.py
+++ b/src/modules/get_cluster_status_db.py
@@ -178,8 +178,7 @@ class HanaClusterStatusChecker(BaseClusterStatusChecker):
 
         for param_name, command in param_commands.items():
             try:
-                cmd_output = self.execute_command_subprocess(command).strip()
-                self.result[param_name] = ET.fromstring(cmd_output).get("value")
+                self.result[param_name] = self.execute_command_subprocess(command).strip()
             except Exception:
                 self.result[param_name] = "unknown"
 

--- a/src/modules/get_pcmk_properties_scs.py
+++ b/src/modules/get_pcmk_properties_scs.py
@@ -246,6 +246,82 @@ class HAClusterValidator(BaseHAClusterValidator):
 
         return parameters
 
+    def _resolve_provider_values(self, expected_value: dict) -> list:
+        """
+        Resolve provider-specific values from a configuration dictionary.
+
+        This method handles the complex logic of extracting appropriate values
+        based on the NFS provider configuration. It supports both provider-specific
+        configurations and fallback to all available providers.
+
+        :param expected_value: Dictionary containing provider configurations
+        :type expected_value: dict
+        :return: List of resolved values for validation
+        :rtype: list
+        :raises TypeError: If expected_value is not a dictionary
+        """
+        if not isinstance(expected_value, dict):
+            raise TypeError("Expected value must be a dictionary for provider resolution")
+
+        provider_values = []
+        if self.nfs_provider and self.nfs_provider in expected_value:
+            provider_config = expected_value[self.nfs_provider]
+            provider_values = self._extract_values_from_config(provider_config)
+        else:
+            for _, provider_config in expected_value.items():
+                extracted_values = self._extract_values_from_config(provider_config)
+                if isinstance(extracted_values, list):
+                    provider_values.extend(extracted_values)
+                else:
+                    provider_values.append(extracted_values)
+
+        return provider_values if isinstance(provider_values, list) else [provider_values]
+
+    def _extract_values_from_config(self, provider_config):
+        """
+        Extract values from a provider configuration structure.
+
+        Handles various configuration formats:
+        - {"value": [list]} or {"value": "single"}
+        - [list] directly
+        - "single" value directly
+
+        :param provider_config: Configuration object to extract values from
+        :type provider_config: dict or list or str
+        :return: Extracted value(s)
+        :rtype: list or str
+        """
+        if isinstance(provider_config, dict) and "value" in provider_config:
+            return provider_config["value"]
+        elif isinstance(provider_config, (list, str)):
+            return provider_config
+        else:
+            return provider_config
+
+    def _compare_value_with_expectations(self, value: str, expected_values) -> str:
+        """
+        Compare a value against expected values and return test status.
+
+        :param value: The actual value to compare
+        :type value: str
+        :param expected_values: Expected value(s) for comparison
+        :type expected_values: str or list
+        :return: Test status (SUCCESS or ERROR)
+        :rtype: str
+        """
+        if isinstance(expected_values, list):
+            return (
+                TestStatus.SUCCESS.value
+                if str(value) in [str(v) for v in expected_values]
+                else TestStatus.ERROR.value
+            )
+        else:
+            return (
+                TestStatus.SUCCESS.value
+                if str(value) == str(expected_values)
+                else TestStatus.ERROR.value
+            )
+
     def _determine_parameter_status(self, value, expected_value):
         """
         Determine the status of a parameter with SCS-specific logic for NFS provider.
@@ -257,60 +333,31 @@ class HAClusterValidator(BaseHAClusterValidator):
         :return: The status of the parameter.
         :rtype: str
         """
+        # Handle tuple format (value, required)
         if isinstance(expected_value, tuple):
             expected_val, required = expected_value
             if not required and (expected_val is None or value == ""):
                 return TestStatus.INFO.value
             expected_value = expected_val
 
+        # Handle empty/null cases
         if expected_value is None or value == "":
             return TestStatus.INFO.value
-        elif isinstance(expected_value, (str, list)):
-            if isinstance(expected_value, list):
-                return (
-                    TestStatus.SUCCESS.value
-                    if str(value) in expected_value
-                    else TestStatus.ERROR.value
-                )
-            else:
-                return (
-                    TestStatus.SUCCESS.value
-                    if str(value) == str(expected_value)
-                    else TestStatus.ERROR.value
-                )
-        elif isinstance(expected_value, dict):
-            provider_values = []
-            if self.nfs_provider and self.nfs_provider in expected_value:
-                provider_config = expected_value[self.nfs_provider]
-                if isinstance(provider_config, dict) and "value" in provider_config:
-                    provider_values = provider_config["value"]
-                else:
-                    provider_values = provider_config
-            else:
-                # If provider is unknown/not set, collect all provider values
-                for provider_key, provider_config in expected_value.items():
-                    if isinstance(provider_config, dict) and "value" in provider_config:
-                        if isinstance(provider_config["value"], list):
-                            provider_values.extend(provider_config["value"])
-                        else:
-                            provider_values.append(provider_config["value"])
-                    elif isinstance(provider_config, list):
-                        provider_values.extend(provider_config)
-                    else:
-                        provider_values.append(provider_config)
 
-            if isinstance(provider_values, list):
-                return (
-                    TestStatus.SUCCESS.value
-                    if str(value) in provider_values
-                    else TestStatus.ERROR.value
-                )
-            else:
-                return (
-                    TestStatus.SUCCESS.value
-                    if str(value) == str(provider_values)
-                    else TestStatus.ERROR.value
-                )
+        # Handle simple string/list cases
+        elif isinstance(expected_value, (str, list)):
+            return self._compare_value_with_expectations(value, expected_value)
+
+        # Handle complex provider-based dictionary cases
+        elif isinstance(expected_value, dict):
+            try:
+                provider_values = self._resolve_provider_values(expected_value)
+                return self._compare_value_with_expectations(value, provider_values)
+            except (TypeError, KeyError) as ex:
+                self.result["message"] += f"Error resolving provider values: {str(ex)} "
+                return TestStatus.ERROR.value
+
+        # Handle unexpected types
         else:
             return TestStatus.ERROR.value
 

--- a/src/roles/ha_db_hana/tasks/block-network.yml
+++ b/src/roles/ha_db_hana/tasks/block-network.yml
@@ -23,8 +23,9 @@
                                             - node_tier == "hana"
                                             - pre_validations_status == "PASSED"
                                             - cluster_status_pre.stonith_action == "reboot"
-                                            - cluster_status_pre.PRIORITY_FENCING_DELAY is not ""
-                                            - cluster_status_pre.PRIORITY_FENCING_DELAY is not "unknown"
+                                            - cluster_status_pre.PRIORITY_FENCING_DELAY is defined
+                                            - cluster_status_pre.PRIORITY_FENCING_DELAY != ""
+                                            - cluster_status_pre.PRIORITY_FENCING_DELAY != "unknown"
   block:
     - name:                                 "Test Execution: Block Network Communication"
       when:                                 ansible_hostname == cluster_status_pre.primary_node
@@ -95,7 +96,8 @@
             operation_step:                 "test_execution"
             database_sid:                   "{{ db_sid | lower }}"
             saphanasr_provider:             "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:             "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:       "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name:   "{{ hana_primitive_resource_name | default('') }}"
           register:                         cluster_status_test_execution_primary
           retries:                          "{{ default_retries }}"
           delay:                            "{{ default_delay }}"
@@ -122,7 +124,8 @@
             operation_step:                 "test_execution"
             database_sid:                   "{{ db_sid | lower }}"
             saphanasr_provider:             "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:             "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:       "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name:   "{{ hana_primitive_resource_name | default('') }}"
           register:                         cluster_status_post_primary
           retries:                          "{{ default_retries }}"
           delay:                            "{{ default_delay }}"
@@ -142,7 +145,8 @@
             operation_step:                 "test_execution"
             database_sid:                   "{{ db_sid | lower }}"
             saphanasr_provider:             "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:             "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:       "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name:   "{{ hana_primitive_resource_name | default('') }}"
           register:                         cluster_status_test_execution_secondary
           retries:                          "{{ default_retries }}"
           delay:                            "{{ default_delay }}"
@@ -160,7 +164,8 @@
             operation_step:                 "test_execution"
             database_sid:                   "{{ db_sid | lower }}"
             saphanasr_provider:             "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:             "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:       "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name:   "{{ hana_primitive_resource_name | default('') }}"
           register:                         cluster_status_post_secondary
           retries:                          "{{ default_retries }}"
           delay:                            "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/block-network.yml
+++ b/src/roles/ha_db_hana/tasks/block-network.yml
@@ -23,6 +23,8 @@
                                             - node_tier == "hana"
                                             - pre_validations_status == "PASSED"
                                             - cluster_status_pre.stonith_action == "reboot"
+                                            - cluster_status_pre.PRIORITY_FENCING_DELAY is not ""
+                                            - cluster_status_pre.PRIORITY_FENCING_DELAY is not "unknown"
   block:
     - name:                                 "Test Execution: Block Network Communication"
       when:                                 ansible_hostname == cluster_status_pre.primary_node
@@ -227,6 +229,7 @@
         test_case_details_from_test_case:   {
                                             "Pre Validations: Remove any location_constraints": "{{ location_constraints_results }}",
                                             "Pre Validations: Validate HANA DB cluster status": "{{ cluster_status_pre }}",
+                                            "Pre Validations: priority-fencing-delay": "{{ cluster_status_pre.PRIORITY_FENCING_DELAY | default('Not Configured') }}",
                                             "Pre Validations: CleanUp any failed resource": "{{ cleanup_failed_resource_pre }}",
                                             "Cluster Status": "{{ cluster_status_pre }}",
                                             }

--- a/src/roles/ha_db_hana/tasks/files/constants.yaml
+++ b/src/roles/ha_db_hana/tasks/files/constants.yaml
@@ -731,7 +731,6 @@ OS_PARAMETERS:
 # === Global INI ===
 # Reading the global.ini file to get the provider and path for the SAPHanaSR resource agent
 GLOBAL_INI:
-  GLOBAL_INI:
   SUSE:
     SAPHanaSR:
       provider:

--- a/src/roles/ha_db_hana/tasks/fs-freeze.yml
+++ b/src/roles/ha_db_hana/tasks/fs-freeze.yml
@@ -59,7 +59,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -76,7 +77,8 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/primary-crash-index.yml
+++ b/src/roles/ha_db_hana/tasks/primary-crash-index.yml
@@ -57,7 +57,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -72,7 +73,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -122,7 +124,8 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/primary-echo-b.yml
+++ b/src/roles/ha_db_hana/tasks/primary-echo-b.yml
@@ -49,7 +49,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
           register:                     cluster_status_test_execution
@@ -64,7 +65,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
           register:                     cluster_status_test_execution
@@ -110,7 +112,8 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/primary-node-crash.yml
+++ b/src/roles/ha_db_hana/tasks/primary-node-crash.yml
@@ -45,7 +45,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -89,7 +90,8 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/primary-node-kill.yml
+++ b/src/roles/ha_db_hana/tasks/primary-node-kill.yml
@@ -46,7 +46,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -63,7 +64,8 @@
                 operation_step:         "test_execution"
                 database_sid:           "{{ db_sid | lower }}"
                 saphanasr_provider:     "{{ saphanasr_provider | default('SAPHanaSR') }}"
-                hana_resource_name:     "{{ hana_resource_name | default('') }}"
+                hana_clone_resource_name: "{{ hana_clone_resource_name | default('') }}"
+                hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
               register:                 cluster_status_test_execution
               retries:                  "{{ default_retries }}"
               delay:                    "{{ default_delay }}"
@@ -108,7 +110,8 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/resource-migration.yml
+++ b/src/roles/ha_db_hana/tasks/resource-migration.yml
@@ -44,12 +44,12 @@
               args:
                 executable:             /bin/bash
               changed_when:             false
-              register:                 hana_resource_id
-              failed_when:              hana_resource_id.rc != 0
+              register:                 hana_clone_resource_id
+              failed_when:              hana_clone_resource_id.rc != 0
 
-            - name:                     "Test Execution: Set fact the hana_resource_name"
+            - name:                     "Test Execution: Set fact the hana_clone_resource_name"
               ansible.builtin.set_fact:
-                hana_resource_name:     "{{ hana_resource_id.stdout }}"
+                hana_clone_resource_name:     "{{ hana_clone_resource_id.stdout }}"
 
         - name:                         "Test Execution: Get HANA resource id"
           when:                         saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR"
@@ -57,38 +57,38 @@
             - name:                     "Try master resource ID"
               ansible.builtin.shell: >-
                                         set -o pipefail && {{ commands
-                                          | selectattr('name','equalto','get_hana_resource_id')
+                                          | selectattr('name','equalto','get_hana_clone_resource_id')
                                           | map(attribute=(ansible_os_family|upper))
                                           | first
                                         }}
               args:
                 executable:             /bin/bash
               changed_when:             false
-              register:                 hana_resource_id
-              failed_when:              hana_resource_id.rc != 0
+              register:                 hana_clone_resource_id
+              failed_when:              hana_clone_resource_id.rc != 0
           rescue:
             - name:                     "Try clone resource ID"
               ansible.builtin.shell: >-
                                         set -o pipefail && {{ commands
-                                          | selectattr('name','equalto','get_hana_resource_id')
+                                          | selectattr('name','equalto','get_hana_clone_resource_id')
                                           | map(attribute='REDHAT')
                                           | first
                                         }}
               args:
                 executable:             /bin/bash
               changed_when:             false
-              register:                 hana_resource_id
-              failed_when:              hana_resource_id.rc != 0
+              register:                 hana_clone_resource_id
+              failed_when:              hana_clone_resource_id.rc != 0
               ignore_errors:            true
           always:
             - name:                     "Test Execution: Set the resource name"
               when:
-                                        - hana_resource_id.rc == 0
-                                        - hana_resource_id.stdout is defined
-                                        - hana_resource_id.stdout | type_debug != 'NoneType'
-                                        - hana_resource_id.stdout | trim | length > 1
+                                        - hana_clone_resource_id.rc == 0
+                                        - hana_clone_resource_id.stdout is defined
+                                        - hana_clone_resource_id.stdout | type_debug != 'NoneType'
+                                        - hana_clone_resource_id.stdout | trim | length > 1
               ansible.builtin.set_fact:
-                hana_resource_name:     "{{ hana_resource_id.stdout }}"
+                hana_clone_resource_name: "{{ hana_clone_resource_id.stdout }}"
 
         - name:                         "Test Execution: Move the resource to the targeted node"
           ansible.builtin.command:      "{{ commands | selectattr(
@@ -104,7 +104,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -160,7 +161,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution_1
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/sbd-fencing.yml
+++ b/src/roles/ha_db_hana/tasks/sbd-fencing.yml
@@ -60,7 +60,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
           register:                     cluster_status_test_execution
@@ -77,7 +78,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/secondary-crash-index.yml
+++ b/src/roles/ha_db_hana/tasks/secondary-crash-index.yml
@@ -57,7 +57,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -71,7 +72,8 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/secondary-echo-b.yml
+++ b/src/roles/ha_db_hana/tasks/secondary-echo-b.yml
@@ -53,7 +53,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
           register:                     cluster_status_test_execution
@@ -67,7 +68,8 @@
             operation_step:             "post_failover"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/ha_db_hana/tasks/secondary-node-kill.yml
+++ b/src/roles/ha_db_hana/tasks/secondary-node-kill.yml
@@ -51,7 +51,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_test_execution
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"
@@ -65,7 +66,8 @@
             operation_step:             "test_execution"
             database_sid:               "{{ db_sid | lower }}"
             saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-            hana_resource_name:         "{{ hana_resource_name | default('') }}"
+            hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+            hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
           register:                     cluster_status_post
           retries:                      "{{ default_retries }}"
           delay:                        "{{ default_delay }}"

--- a/src/roles/misc/tasks/cluster-report.yml
+++ b/src/roles/misc/tasks/cluster-report.yml
@@ -12,7 +12,8 @@
     operation_step:                     "cluster_report_collection"
     database_sid:                       "{{ db_sid | lower | default('') }}"
     saphanasr_provider:                 "{{ saphanasr_provider | default('SAPHanaSR') }}"
-    hana_resource_name:                 "{{ hana_resource_name | default('') }}"
+    hana_clone_resource_name:           "{{ hana_clone_resource_name | default('') }}"
+    hana_primitive_resource_name:       "{{ hana_primitive_resource_name | default('') }}"
   register:                             cluster_status
   failed_when:                          cluster_status.primary_node == ""
 

--- a/src/roles/misc/tasks/pre-validations-db.yml
+++ b/src/roles/misc/tasks/pre-validations-db.yml
@@ -32,54 +32,74 @@
           args:
             executable:             /bin/bash
           changed_when:             false
-          register:                 hana_resource_id
-          failed_when:              hana_resource_id.rc != 0
+          register:                 hana_clone_resource_id
+          failed_when:              hana_clone_resource_id.rc != 0
 
-        - name:                     "Pre validation: Set fact the hana_resource_name"
+        - name:                     "Pre validation: Set fact the hana_clone_resource_name"
           ansible.builtin.set_fact:
-            hana_resource_name:     "{{ hana_resource_id.stdout }}"
+            hana_clone_resource_name:     "{{ hana_clone_resource_id.stdout }}"
 
-    - name:                         "Pre validation: Get HANA resource id"
+    - name:                         "Pre validation: Get HANA Clone resource id"
       when:                         saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR"
       block:
         - name:                     "Try master resource ID"
           become:                   true
           ansible.builtin.shell: >-
                                     set -o pipefail && {{ commands
-                                      | selectattr('name','equalto','get_hana_resource_id')
+                                      | selectattr('name','equalto','get_hana_clone_resource_id')
                                       | map(attribute=(ansible_os_family|upper))
                                       | first
                                     }}
           args:
             executable:             /bin/bash
           changed_when:             false
-          register:                 hana_resource_id
-          failed_when:              hana_resource_id.rc != 0
+          register:                 hana_clone_resource_id
+          failed_when:              hana_clone_resource_id.rc != 0
       rescue:
         - name:                     "Try clone resource ID"
           become:                   true
           ansible.builtin.shell: >-
                                     set -o pipefail && {{ commands
-                                      | selectattr('name','equalto','get_hana_resource_id')
+                                      | selectattr('name','equalto','get_hana_clone_resource_id')
                                       | map(attribute='REDHAT')
                                       | first
                                     }}
           args:
             executable:             /bin/bash
           changed_when:             false
-          register:                 hana_resource_id
-          failed_when:              hana_resource_id.rc != 0
+          register:                 hana_clone_resource_id
+          failed_when:              hana_clone_resource_id.rc != 0
           ignore_errors:            true
       always:
         - name:                     "Test Execution: Set the resource name"
           when:
-                                    - hana_resource_id.rc == 0
-                                    - hana_resource_id.stdout is defined
-                                    - hana_resource_id.stdout | type_debug != 'NoneType'
-                                    - hana_resource_id.stdout | trim | length > 1
+                                    - hana_clone_resource_id.rc == 0
+                                    - hana_clone_resource_id.stdout is defined
+                                    - hana_clone_resource_id.stdout | type_debug != 'NoneType'
+                                    - hana_clone_resource_id.stdout | trim | length > 1
           ansible.builtin.set_fact:
-            hana_resource_name:     "{{ hana_resource_id.stdout }}"
+            hana_clone_resource_name:     "{{ hana_clone_resource_id.stdout }}"
 
+    - name:                         "Pre validation: Get HANA Primitive resource id"
+      when:                         saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR"
+      block:
+        - name:                     "Pre validation: Get HANA Primitive resource id"
+          become:                   true
+          ansible.builtin.shell: >-
+                                    set -o pipefail && {{ commands
+                                      | selectattr('name','equalto','get_hana_primitive_resource_id')
+                                      | map(attribute=(ansible_os_family|upper))
+                                      | first
+                                    }}
+          args:
+            executable:             /bin/bash
+          changed_when:             false
+          register:                 hana_primitive_resource_id
+          failed_when:              hana_primitive_resource_id.rc != 0
+
+        - name:                     "Pre validation: Set fact the hana_clone_resource_name"
+          ansible.builtin.set_fact:
+            hana_primitive_resource_name: "{{ hana_primitive_resource_id.stdout }}"
 
     - name:                         "Pre Validation: Validate HANA DB cluster status on primary node"
       become:                       true
@@ -88,7 +108,8 @@
         operation_step:             "pre_failover"
         database_sid:               "{{ db_sid | lower }}"
         saphanasr_provider:         "{{ saphanasr_provider | default('SAPHanaSR') }}"
-        hana_resource_name:         "{{ hana_resource_name | default('') }}"
+        hana_clone_resource_name:   "{{ hana_clone_resource_name | default('') }}"
+        hana_primitive_resource_name: "{{ hana_primitive_resource_name | default('') }}"
       register:                     cluster_status_pre
       until:                        cluster_status_pre.primary_node != "" or
                                     cluster_status_pre.secondary_node != ""

--- a/src/roles/misc/tasks/pre-validations-db.yml
+++ b/src/roles/misc/tasks/pre-validations-db.yml
@@ -97,7 +97,7 @@
           register:                 hana_primitive_resource_id
           failed_when:              hana_primitive_resource_id.rc != 0
 
-        - name:                     "Pre validation: Set fact the hana_clone_resource_name"
+        - name:                     "Pre validation: Set fact the hana_primitive_resource_name"
           ansible.builtin.set_fact:
             hana_primitive_resource_name: "{{ hana_primitive_resource_id.stdout }}"
 

--- a/src/vars/input-api.yaml
+++ b/src/vars/input-api.yaml
@@ -267,7 +267,11 @@ ascs_stonith_timeout:               120
 
 # Commands for HANA DB HA Test Cases based on OS family
 commands:
-  - name:                           get_hana_resource_id
+  - name:                           get_hana_primitive_resource_id
+    SUSE:                           "cibadmin --query --xpath \"//primitive[@type='SAPHana']\" --node-path | grep -oP \"master\\[@id='\\K[^']+\""
+    REDHAT:                         "cibadmin --query --xpath \"//primitive[@type='SAPHana']\" --node-path | grep -oP \"primitive\\[@id='\\K[^']+\""
+
+  - name:                           get_hana_clone_resource_id
     SUSE:                           "cibadmin --query --xpath \"//primitive[@type='SAPHana']\" --node-path | grep -oP \"master\\[@id='\\K[^']+\""
     REDHAT:                         "cibadmin --query --xpath \"//primitive[@type='SAPHana']\" --node-path | grep -oP \"clone\\[@id='\\K[^']+\""
 

--- a/tests/modules/get_cluster_status_db_test.py
+++ b/tests/modules/get_cluster_status_db_test.py
@@ -51,9 +51,9 @@ class TestHanaClusterStatusChecker:
             hana_resource_name="rsc_SAPHanaCon_TEST_HDB00",
         )
 
-    def test_get_automation_register(self, mocker, hana_checker_classic):
+    def test_get_cluster_pramaeters(self, mocker, hana_checker_classic):
         """
-        Test the _get_automation_register method.
+        Test the _get_cluster_pramaeters method.
 
         :param mocker: Mocking library for Python.
         :type mocker: _mocker.MagicMock
@@ -67,13 +67,13 @@ class TestHanaClusterStatusChecker:
             + 'name="AUTOMATED_REGISTER" value="true"/>',
         )
 
-        hana_checker_classic._get_automation_register()
+        hana_checker_classic._get_cluster_pramaeters()
 
         assert hana_checker_classic.result["AUTOMATED_REGISTER"] == "true"
 
-    def test_get_automation_register_exception(self, mocker, hana_checker_classic):
+    def test_get_cluster_pramaeters_exception(self, mocker, hana_checker_classic):
         """
-        Test the _get_automation_register method when an exception occurs.
+        Test the _get_cluster_pramaeters method when an exception occurs.
 
         :param mocker: Mocking library for Python.
         :type mocker: _mocker.MagicMock
@@ -84,7 +84,7 @@ class TestHanaClusterStatusChecker:
             hana_checker_classic, "execute_command_subprocess", side_effect=Exception("Test error")
         )
 
-        hana_checker_classic._get_automation_register()
+        hana_checker_classic._get_cluster_pramaeters()
 
         assert hana_checker_classic.result["AUTOMATED_REGISTER"] == "unknown"
 
@@ -257,7 +257,7 @@ class TestHanaClusterStatusChecker:
             return_value={"status": "PASSED"},
         )
 
-        mock_get_automation = mocker.patch.object(hana_checker_classic, "_get_automation_register")
+        mock_get_automation = mocker.patch.object(hana_checker_classic, "_get_cluster_pramaeters")
 
         result = hana_checker_classic.run()
 

--- a/tests/modules/get_cluster_status_db_test.py
+++ b/tests/modules/get_cluster_status_db_test.py
@@ -55,7 +55,7 @@ class TestHanaClusterStatusChecker:
 
     def test_get_cluster_pramaeters(self, mocker, hana_checker_classic):
         """
-        Test the _get_cluster_pramaeters method.
+        Test the _get_cluster_parameters method.
 
         :param mocker: Mocking library for Python.
         :type mocker: _mocker.MagicMock
@@ -65,17 +65,16 @@ class TestHanaClusterStatusChecker:
         mocker.patch.object(
             hana_checker_classic,
             "execute_command_subprocess",
-            return_value='<nvpair id="cib-bootstrap-options-AUTOMATED_REGISTER" '
-            + 'name="AUTOMATED_REGISTER" value="true"/>',
+            return_value='true',
         )
 
-        hana_checker_classic._get_cluster_pramaeters()
+        hana_checker_classic._get_cluster_parameters()
 
         assert hana_checker_classic.result["AUTOMATED_REGISTER"] == "true"
 
     def test_get_cluster_pramaeters_exception(self, mocker, hana_checker_classic):
         """
-        Test the _get_cluster_pramaeters method when an exception occurs.
+        Test the _get_cluster_parameters method when an exception occurs.
 
         :param mocker: Mocking library for Python.
         :type mocker: _mocker.MagicMock
@@ -86,7 +85,7 @@ class TestHanaClusterStatusChecker:
             hana_checker_classic, "execute_command_subprocess", side_effect=Exception("Test error")
         )
 
-        hana_checker_classic._get_cluster_pramaeters()
+        hana_checker_classic._get_cluster_parameters()
 
         assert hana_checker_classic.result["AUTOMATED_REGISTER"] == "unknown"
 
@@ -259,7 +258,7 @@ class TestHanaClusterStatusChecker:
             return_value={"status": "PASSED"},
         )
 
-        mock_get_automation = mocker.patch.object(hana_checker_classic, "_get_cluster_pramaeters")
+        mock_get_automation = mocker.patch.object(hana_checker_classic, "_get_cluster_parameters")
 
         result = hana_checker_classic.run()
 

--- a/tests/modules/get_cluster_status_db_test.py
+++ b/tests/modules/get_cluster_status_db_test.py
@@ -72,7 +72,7 @@ class TestHanaClusterStatusChecker:
 
         assert hana_checker_classic.result["AUTOMATED_REGISTER"] == "true"
 
-    def test_get_cluster_pramaeters_exception(self, mocker, hana_checker_classic):
+    def test_get_cluster_parameters_exception(self, mocker, hana_checker_classic):
         """
         Test the _get_cluster_parameters method when an exception occurs.
 

--- a/tests/modules/get_cluster_status_db_test.py
+++ b/tests/modules/get_cluster_status_db_test.py
@@ -32,7 +32,8 @@ class TestHanaClusterStatusChecker:
             ansible_os_family=OperatingSystemFamily.REDHAT,
             saphanasr_provider=HanaSRProvider.SAPHANASR,
             db_instance_number="00",
-            hana_resource_name="rsc_SAPHanaCon_TEST_HDB00",
+            hana_clone_resource_name="rsc_SAPHanaCon_TEST_HDB00",
+            hana_primitive_resource_name="rsc_SAPHanaPrm_TEST_HDB00",
         )
 
     @pytest.fixture
@@ -48,7 +49,8 @@ class TestHanaClusterStatusChecker:
             ansible_os_family=OperatingSystemFamily.SUSE,
             saphanasr_provider=HanaSRProvider.ANGI,
             db_instance_number="00",
-            hana_resource_name="rsc_SAPHanaCon_TEST_HDB00",
+            hana_clone_resource_name="rsc_SAPHanaCon_TEST_HDB00",
+            hana_primitive_resource_name="rsc_SAPHanaCon_TEST_HDB00",
         )
 
     def test_get_cluster_pramaeters(self, mocker, hana_checker_classic):

--- a/tests/modules/get_cluster_status_db_test.py
+++ b/tests/modules/get_cluster_status_db_test.py
@@ -65,7 +65,7 @@ class TestHanaClusterStatusChecker:
         mocker.patch.object(
             hana_checker_classic,
             "execute_command_subprocess",
-            return_value='true',
+            return_value="true",
         )
 
         hana_checker_classic._get_cluster_parameters()

--- a/tests/modules/get_pcmk_properties_scs_test.py
+++ b/tests/modules/get_pcmk_properties_scs_test.py
@@ -369,7 +369,6 @@ class TestHAClusterValidator:
         status = validator._determine_parameter_status(
             "10.0.1.101", (["10.0.1.100", "10.0.1.101"], False)
         )
-        print(f"Actual status: {status}, Expected: {TestStatus.SUCCESS.value}")
         assert status == TestStatus.SUCCESS.value
 
     def test_determine_parameter_status_info_cases(self, validator):

--- a/tests/roles/ha_db_hana/block_network_test.py
+++ b/tests/roles/ha_db_hana/block_network_test.py
@@ -34,7 +34,11 @@ class TestBlockNetworkTest(RolesTestingBaseDB):
 
         commands = [
             {
-                "name": "get_hana_resource_id",
+                "name": "get_hana_clone_resource_id",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+            {
+                "name": "get_hana_primitive_resource_id",
                 "SUSE": "cibadmin --query --scope resources",
             },
             {

--- a/tests/roles/ha_db_hana/primary_node_ops_test.py
+++ b/tests/roles/ha_db_hana/primary_node_ops_test.py
@@ -100,7 +100,11 @@ class TestDbHDBOperations(RolesTestingBaseDB):
 
         commands = [
             {
-                "name": "get_hana_resource_id",
+                "name": "get_hana_clone_resource_id",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+            {
+                "name": "get_hana_primitive_resource_id",
                 "SUSE": "cibadmin --query --scope resources",
             },
             {

--- a/tests/roles/ha_db_hana/resource_migration_test.py
+++ b/tests/roles/ha_db_hana/resource_migration_test.py
@@ -53,11 +53,15 @@ class TestDbResourceMigration(RolesTestingBaseDB):
         commands = [
             {
                 "name": "resource_migration_cmd",
-                "SUSE": "crm resource move {{ hana_resource_name | default('msl_SAPHana_' ~ "
+                "SUSE": "crm resource move {{ hana_clone_resource_name | default('msl_SAPHana_' ~ "
                 "(db_sid | upper) ~ '_HDB' ~ db_instance_number) }} db02 force",
             },
             {
-                "name": "get_hana_resource_id",
+                "name": "get_hana_clone_resource_id",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+            {
+                "name": "get_hana_primitive_resource_id",
                 "SUSE": "cibadmin --query --scope resources",
             },
             {

--- a/tests/roles/ha_db_hana/secondary_node_ops_test.py
+++ b/tests/roles/ha_db_hana/secondary_node_ops_test.py
@@ -71,7 +71,11 @@ class TestDbSecondaryHDBOperations(RolesTestingBaseDB):
 
         commands = [
             {
-                "name": "get_hana_resource_id",
+                "name": "get_hana_clone_resource_id",
+                "SUSE": "cibadmin --query --scope resources",
+            },
+            {
+                "name": "get_hana_primitive_resource_id",
                 "SUSE": "cibadmin --query --scope resources",
             },
             {

--- a/tests/roles/mock_data/get_cluster_status_db.txt
+++ b/tests/roles/mock_data/get_cluster_status_db.txt
@@ -11,7 +11,8 @@ def main():
             database_sid=dict(type="str", required=True),
             saphanasr_provider=dict(type="str", required=True),
             db_instance_number=dict(type="str", required=True),
-            hana_resource_name=dict(type="str", default="")
+            hana_clone_resource_name=dict(type="str", default=""),
+            hana_primitive_resource_name=dict(type="str", default="")
         )
     )
 
@@ -40,7 +41,8 @@ def main():
             "replication_mode": "sync",
             "primary_site_name": "db01",
             "operation_mode": "active",
-            "stonith_action": "reboot"
+            "stonith_action": "reboot",
+            "PRIORITY_FENCING_DELAY": "15s"
         }
     elif counter == 1 or counter == 2:
         result = {
@@ -53,7 +55,8 @@ def main():
             "replication_mode": "sync",
             "primary_site_name": "db01",
             "operation_mode": "active",
-            "stonith_action": "reboot"
+            "stonith_action": "reboot",
+            "PRIORITY_FENCING_DELAY": "15s"
         }
     else:
         result = {
@@ -66,7 +69,8 @@ def main():
             "replication_mode": "sync",
             "primary_site_name": "db01",
             "operation_mode": "active",
-            "stonith_action": "reboot"
+            "stonith_action": "reboot",
+            "PRIORITY_FENCING_DELAY": "15s"
         }
 
     module.exit_json(**result)

--- a/tests/roles/mock_data/secondary_get_cluster_status_db.txt
+++ b/tests/roles/mock_data/secondary_get_cluster_status_db.txt
@@ -11,7 +11,8 @@ def main():
             database_sid=dict(type="str", required=True),
             saphanasr_provider=dict(type="str", required=True),
             db_instance_number=dict(type="str", required=True),
-            hana_resource_name=dict(type="str", default="")
+            hana_clone_resource_name=dict(type="str", default=""),
+            hana_primitive_resource_name=dict(type="str", default="")
         )
     )
 
@@ -40,7 +41,8 @@ def main():
             "replication_mode": "sync",
             "primary_site_name": "db01",
             "operation_mode": "active",
-            "stonith_action": "reboot"
+            "stonith_action": "reboot",
+            "PRIORITY_FENCING_DELAY": "15s"
         }
     elif counter == 1 or counter == 2:
         result = {
@@ -53,7 +55,8 @@ def main():
             "replication_mode": "sync",
             "primary_site_name": "db01",
             "operation_mode": "active",
-            "stonith_action": "reboot"
+            "stonith_action": "reboot",
+            "PRIORITY_FENCING_DELAY": "15s"
         }
     else:
         result = {
@@ -66,7 +69,8 @@ def main():
             "replication_mode": "sync",
             "primary_site_name": "db01",
             "operation_mode": "active",
-            "stonith_action": "reboot"
+            "stonith_action": "reboot",
+            "PRIORITY_FENCING_DELAY": "15s"
         }
 
     module.exit_json(**result)


### PR DESCRIPTION
This pull request introduces several improvements and refactoring to the cluster status and resource validation logic, with a focus on better handling of resource parameters and provider-specific configurations. The main changes include refactoring the way HANA resource names are passed and used, adding support for retrieving and validating the `priority-fencing-delay` cluster parameter, and simplifying provider-based value resolution for resource validation.

### Cluster Status Parameter Handling

* Refactored the handling of HANA resource names in `get_cluster_status_db.py` by splitting the single `hana_resource_name` parameter into `hana_clone_resource_name` and `hana_primitive_resource_name` for more precise resource identification. All related Ansible task files were updated to use the new parameters. [[1]](diffhunk://#diff-d0f5b8b712bff563ba0387aa11086b766ab00ff5059be92059476e8f9a4b8439L149-R157) [[2]](diffhunk://#diff-d0f5b8b712bff563ba0387aa11086b766ab00ff5059be92059476e8f9a4b8439L297-R306) [[3]](diffhunk://#diff-d0f5b8b712bff563ba0387aa11086b766ab00ff5059be92059476e8f9a4b8439L310-R320) [[4]](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3L96-R100) [[5]](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3L123-R128) [[6]](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3L143-R149) [[7]](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3L161-R168) [[8]](diffhunk://#diff-81aa6c21cc2087674cdc2fde958484d4e2f1e188ecc9cce00a909e5420779363L62-R63) [[9]](diffhunk://#diff-81aa6c21cc2087674cdc2fde958484d4e2f1e188ecc9cce00a909e5420779363L79-R81) [[10]](diffhunk://#diff-2e872e645177f9ab6c6b26f3e1c9f0218898692a4327b6e18d6509dc00d8eaa1L60-R61)
* Updated the cluster status checker to retrieve both `AUTOMATED_REGISTER` and the new `PRIORITY_FENCING_DELAY` parameters, storing them in the result dictionary for downstream use and validation. [[1]](diffhunk://#diff-835a20ef90ff0c67d7556963b6f4657684c334689b584ffa99810b4e90eebab6L33-R47) [[2]](diffhunk://#diff-d0f5b8b712bff563ba0387aa11086b766ab00ff5059be92059476e8f9a4b8439L17-R20) [[3]](diffhunk://#diff-d0f5b8b712bff563ba0387aa11086b766ab00ff5059be92059476e8f9a4b8439R166-R183) [[4]](diffhunk://#diff-d0f5b8b712bff563ba0387aa11086b766ab00ff5059be92059476e8f9a4b8439L284-R292) [[5]](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3R26-R28) [[6]](diffhunk://#diff-512cb57688ccc3dcf62db15550edcb187b0cc6eda9a54f449d41b083c4e526b3R237)

### Provider-Specific Resource Validation

* Refactored and simplified provider-based value resolution logic in `get_pcmk_properties_scs.py` by introducing helper methods `_resolve_provider_values`, `_extract_values_from_config`, and `_compare_value_with_expectations`. This makes provider-specific validation more robust and easier to maintain. [[1]](diffhunk://#diff-22fc3dba38a310fe7173413bde12435e1b98d44ae4d8d05814d36b505cad8cfbR249-R324) [[2]](diffhunk://#diff-22fc3dba38a310fe7173413bde12435e1b98d44ae4d8d05814d36b505cad8cfbR336-R360)

### Minor Fixes and Cleanups

* Fixed a duplicate key in the `constants.yaml` file for `GLOBAL_INI` to ensure proper configuration loading.

These changes improve the clarity, maintainability, and extensibility of cluster resource parameter handling and validation logic.