### PR TITLE
Update disk performance thresholds for HANA checks

### DIFF
--- a/src/roles/configuration_checks/tasks/files/hana.yml
+++ b/src/roles/configuration_checks/tasks/files/hana.yml
@@ -1289,7 +1289,7 @@ checks:
 
   - id:                                 "DB-HANA-0050"
     name:                               "Disk performance for /hana/data (MBPS)"
-    description:                        "The disk performance for /hana/data should be >= 64 MByte/s"
+    description:                        "The disk performance for /hana/data should be >= 400 MByte/s"
     category:                           *sap_check
     severity:                           *high
     workload:                           *sap
@@ -1307,7 +1307,7 @@ checks:
       mount_point:                      "/hana/data"
     validator_type:                     *range
     validator_args:
-      min:                              "64"
+      min:                              "400"
     report:                             *check
     references:
       sap:                              "2972496"
@@ -1315,7 +1315,7 @@ checks:
 
   - id:                                 "DB-HANA-0051"
     name:                               "Disk performance for /hana/log (MBPS)"
-    description:                        "The disk performance for /hana/log should be >= 64 MByte/s"
+    description:                        "The disk performance for /hana/log should be >= 250 MByte/s"
     category:                           *sap_check
     severity:                           *high
     workload:                           *sap
@@ -1333,7 +1333,7 @@ checks:
       mount_point:                      "/hana/log"
     validator_type:                     *range
     validator_args:
-      min:                              "64"
+      min:                              "250"
     report:                             *check
     references:
       sap:                              "2972496"


### PR DESCRIPTION
This pull request updates the minimum disk performance requirements for SAP HANA data and log directories in the `hana.yml` configuration checks. The changes align the checks with recommendations and best practices for SAP HANA deployments.

**Updated disk performance thresholds:**

* Increased the minimum required disk performance for `/hana/data` from 64 MB/s to 400 MB/s in both the description and the validator arguments. [[1]](diffhunk://#diff-fd7f55bf0703585f2453c5399e14913a36e97366843e648e65651d21e9f58c33L1292-R1292) [[2]](diffhunk://#diff-fd7f55bf0703585f2453c5399e14913a36e97366843e648e65651d21e9f58c33L1310-R1318)
* Increased the minimum required disk performance for `/hana/log` from 64 MB/s to 250 MB/s in both the description and the validator arguments. [[1]](diffhunk://#diff-fd7f55bf0703585f2453c5399e14913a36e97366843e648e65651d21e9f58c33L1310-R1318) [[2]](diffhunk://#diff-fd7f55bf0703585f2453c5399e14913a36e97366843e648e65651d21e9f58c33L1336-R1336)