### PR TITLE
Fix/ossf scorecard workflow

### DIFF
--- a/.github/workflows/ossf-scoreboard.yml
+++ b/.github/workflows/ossf-scoreboard.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
This pull request updates dependencies in the `.github/workflows/ossf-scoreboard.yml` workflow to use newer commit SHAs for both the OSSF Scorecard action and the upload to GitHub's code scanning dashboard. These updates help ensure that the workflow uses the latest bug fixes and improvements from these actions.

Dependency updates:

* Updated `ossf/scorecard-action` commit to use version 2.4.3, which may include important bug fixes or improvements.
* Updated `github/codeql-action/upload-sarif` commit for the code scanning upload step.