### PR TITLE
Enhance setup script with optional flags for upgrade and Python interpreter

### DIFF
--- a/docs/SETUP.MD
+++ b/docs/SETUP.MD
@@ -152,6 +152,30 @@ cd sap-automation-qa
 ./scripts/setup.sh
 ```
 
+The setup script accepts the following optional flags:
+
+| Flag | Description |
+|------|-------------|
+| `--upgrade`, `-u` | Remove the existing virtual environment and recreate it from scratch. |
+| `--python <executable>`, `-p <executable>` | Use a specific Python interpreter for the virtual environment (e.g. `/usr/bin/python3.11`). Defaults to `python3`. The interpreter must be Python 3.10 or later. |
+| `--help`, `-h` | Display usage information. |
+
+**Examples:**
+
+```bash
+# Standard incremental setup (default)
+./scripts/setup.sh
+
+# Full upgrade — destroy and recreate the virtual environment
+./scripts/setup.sh --upgrade
+
+# Create the virtual environment with a specific Python version
+./scripts/setup.sh --python /usr/bin/python3.11
+
+# Upgrade and switch to a different Python version
+./scripts/setup.sh --upgrade --python /usr/bin/python3.11
+```
+
 1.5. **Activate the python environment**:
 
 ```bash

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,6 +13,56 @@ set_output_context
 # Ensure we're in the project root directory
 cd "$(dirname "$script_dir")"
 
+# Usage / help
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --upgrade, -u              Remove the existing virtual environment and
+                             recreate it from scratch (full upgrade).
+  --python,  -p <executable> Use a specific Python interpreter for the
+                             virtual environment (e.g. python3.11,
+                             /usr/bin/python3.12). Defaults to python3.
+  --help,    -h              Show this help message and exit.
+
+Examples:
+  $(basename "$0")                          # incremental setup
+  $(basename "$0") --upgrade                # destroy & recreate venv
+  $(basename "$0") -p python3.11            # use Python 3.11
+  $(basename "$0") -u -p /usr/bin/python3.12 # upgrade with Python 3.12
+EOF
+    exit 0
+}
+
+# Parse arguments
+UPGRADE=false
+PYTHON_BIN="python3"   # default interpreter
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --upgrade|-u)
+            UPGRADE=true
+            shift
+            ;;
+        --python|-p)
+            if [[ -z "${2:-}" ]]; then
+                log "ERROR" "--python requires a value (e.g. python3.11 or /usr/bin/python3.12)."
+                exit 1
+            fi
+            PYTHON_BIN="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            log "ERROR" "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
 packages=("python3-pip" "sshpass" "python3-venv")
 install_packages "${packages[@]}"
 
@@ -28,18 +78,42 @@ if ! command_exists az; then
 		fi
 fi
 
-# Verify Python3 is available
-if ! command_exists python3; then
-    log "ERROR" "Python3 is not available after installation. Please install Python3 manually."
+# Resolve & validate the requested Python interpreter
+if ! command -v "$PYTHON_BIN" &>/dev/null; then
+    log "ERROR" "Python interpreter '$PYTHON_BIN' not found. Please install it or provide a valid path."
+    exit 1
+fi
+
+PYTHON_BIN="$(command -v "$PYTHON_BIN")"   # resolve to absolute path
+PYTHON_VERSION=$("$PYTHON_BIN" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+log "INFO" "Using Python interpreter: $PYTHON_BIN (Python $PYTHON_VERSION)"
+
+# Enforce minimum Python 3.10
+MINOR=${PYTHON_VERSION#3.}
+if [[ "${PYTHON_VERSION%%.*}" -lt 3 ]] || [[ "$MINOR" -lt 10 ]]; then
+    log "ERROR" "Python >= 3.10 is required. Detected $PYTHON_VERSION at $PYTHON_BIN."
     exit 1
 fi
 
 
+# Upgrade: tear down existing venv so it is rebuilt from scratch
+if [[ "$UPGRADE" == true ]]; then
+    if [[ -d ".venv" ]]; then
+        log "INFO" "Upgrade requested — removing existing virtual environment..."
+        # Deactivate if we are inside the venv (ignore errors when not active)
+        deactivate 2>/dev/null || true
+        rm -rf .venv
+        log "INFO" "Existing virtual environment removed."
+    else
+        log "INFO" "Upgrade requested but no existing virtual environment found. Creating fresh."
+    fi
+fi
+
 # Create virtual environment if it doesn't exist
-if [ ! -d ".venv" ]; then
-    log "INFO" "Creating Python virtual environment..."
-    if python3 -m venv .venv; then
-        log "INFO" "Python virtual environment created."
+if [[ ! -d ".venv" ]]; then
+    log "INFO" "Creating Python virtual environment with $PYTHON_BIN ..."
+    if "$PYTHON_BIN" -m venv .venv; then
+        log "INFO" "Python virtual environment created (Python $PYTHON_VERSION)."
     else
         log "ERROR" "Failed to create Python virtual environment."
         exit 1


### PR DESCRIPTION
This pull request introduces improvements to the `setup.sh` script and its documentation, making the setup process more flexible and user-friendly. The main changes include adding support for optional flags to control upgrade and Python interpreter selection, enforcing a minimum Python version, and updating the documentation to reflect these enhancements.

Enhancements to setup script functionality:

* Added support for optional flags: `--upgrade`/`-u` to rebuild the virtual environment, `--python`/`-p` to specify a Python interpreter, and `--help`/`-h` for usage information. Argument parsing and validation were implemented for these options.
* Enforced minimum Python version (>= 3.10) and resolved the Python interpreter to its absolute path, with clear error handling if requirements are not met.
* Improved upgrade logic: when the `--upgrade` flag is used, the script removes the existing virtual environment before recreating it.

Documentation updates:

* Updated `docs/SETUP.MD` to include a table describing the new flags, their usage, and example commands for various setup scenarios.