### PR TITLE
Refactor cluster validation keys and update scale-out HSR configuration

### DIFF
--- a/src/module_utils/get_pcmk_properties.py
+++ b/src/module_utils/get_pcmk_properties.py
@@ -100,8 +100,9 @@ class BaseHAClusterValidator(SapAutomationQA, ABC):
         provider_topology_key = (
             f"{provider.name.lower()}_{topology.value}" if provider and topology else None
         )
+        topology_key = topology.value if topology else None
 
-        lookup_keys = [self.fencing_mechanism, provider_topology_key, self.os_type]
+        lookup_keys = [self.fencing_mechanism, provider_topology_key, topology_key, self.os_type]
 
         for key in lookup_keys:
             if not key:
@@ -157,7 +158,8 @@ class BaseHAClusterValidator(SapAutomationQA, ABC):
         provider_topology_key = (
             f"{provider.name.lower()}_{topology.value}" if provider and topology else None
         )
-        for key in [self.fencing_mechanism, provider_topology_key, self.os_type]:
+        topology_key = topology.value if topology else None
+        for key in [self.fencing_mechanism, provider_topology_key, topology_key, self.os_type]:
             if not key:
                 continue
             override = self.constants["VALID_CONFIGS"].get(key, {}).get(param_name, {})

--- a/src/roles/ha_db_hana/tasks/files/constants.yaml
+++ b/src/roles/ha_db_hana/tasks/files/constants.yaml
@@ -114,7 +114,7 @@ VALID_CONFIGS:
     stonith-timeout:
       value:                        ["210", "210s"]
       required:                     true
-  angi_scale_out_hsr:
+  scale_out_hsr:
     migration-threshold:
       value:                        ["50"]
       required:                     true

--- a/src/roles/ha_db_hana/tasks/secondary-worker-node-kill.yml
+++ b/src/roles/ha_db_hana/tasks/secondary-worker-node-kill.yml
@@ -10,6 +10,7 @@
 
 - name:                                 "Test Execution: Secondary Worker Node Kill"
   ansible.builtin.include_tasks:        "roles/ha_db_hana/tasks/includes/scaleout-worker-operation.yml"
+  when:                                 saphanasr_provider | default('SAPHanaSR') == "SAPHanaSR-angi"
   vars:
     hana_test_target_site_label:        "secondary"
     hana_test_target_worker_node:       "{{ secondary_worker_nodes | first | default('') }}"

--- a/src/roles/misc/tasks/pre-validations-db.yml
+++ b/src/roles/misc/tasks/pre-validations-db.yml
@@ -182,3 +182,12 @@
                                     - cluster_status_pre.pacemaker_status | default('') == "running"
       ansible.builtin.set_fact:
         pre_validations_status:     "PASSED"
+
+  rescue:
+    - name:                         "Pre Validation: Set pre Validation status to FAILED on error"
+      ansible.builtin.set_fact:
+        pre_validations_status:     "FAILED"
+
+    - name:                         "Pre Validation: Log failure details"
+      ansible.builtin.debug:
+        msg:                        "Pre-validation failed. The test case will be skipped."

--- a/src/roles/misc/tasks/pre-validations-scs.yml
+++ b/src/roles/misc/tasks/pre-validations-scs.yml
@@ -37,3 +37,12 @@
                                     - cluster_status_pre.pacemaker_status == "running"
       ansible.builtin.set_fact:
         pre_validations_status:     "PASSED"
+
+  rescue:
+    - name:                         "Pre Validation: Set pre Validation status to FAILED on error"
+      ansible.builtin.set_fact:
+        pre_validations_status:     "FAILED"
+
+    - name:                         "Pre Validation: Log failure details"
+      ansible.builtin.debug:
+        msg:                        "Pre-validation failed. The test case will be skipped."

--- a/tests/modules/get_pcmk_properties_db_test.py
+++ b/tests/modules/get_pcmk_properties_db_test.py
@@ -355,6 +355,9 @@ DUMMY_CONSTANTS = {
         },
         "azure-fence-agent": {"priority": {"value": "10", "required": False}},
         "sbd": {"pcmk_delay_max": {"value": "30", "required": False}},
+        "scale_out_hsr": {
+            "migration-threshold": {"value": ["50"], "required": True},
+        },
     },
     "RSC_DEFAULTS": {
         "resource-stickiness": {"value": "1000", "required": False},
@@ -1234,3 +1237,13 @@ class TestHAClusterValidator:
         assert validator_scaleout.hana_topology == (HanaTopology.SCALE_OUT_HSR)
         defaults = validator_scaleout.constants["GLOBAL_INI"].get(validator_scaleout.os_type, {})
         assert "SAPHanaController" in defaults
+
+    def test_scaleout_migration_threshold_expected_value(self, validator_scaleout):
+        """
+        Test that scale-out HSR resolves migration-threshold to 50 via topology key.
+        """
+        result = validator_scaleout._get_expected_value("rsc_defaults", "migration-threshold")
+        assert result is not None
+        expected_value, is_required = result
+        assert expected_value == ["50"]
+        assert is_required is True


### PR DESCRIPTION
This pull request updates the logic for resolving expected property values in the `get_pcmk_properties` module, specifically improving how the topology key is handled and ensuring correct configuration for scale-out HSR scenarios. It also updates test cases and configuration files to reflect these changes.

**Enhancements to topology key handling:**

* The `_get_expected_value` and `_get_resource_expected_value` methods in `src/module_utils/get_pcmk_properties.py` now include a direct `topology_key` in their lookup order, ensuring that topology-specific configurations (like scale-out HSR) are correctly resolved. [[1]](diffhunk://#diff-3487cdd60ef15f60d186276f2da2d25df191d059f2f8eaaa5061f5f3d7679c48R103-R105) [[2]](diffhunk://#diff-3487cdd60ef15f60d186276f2da2d25df191d059f2f8eaaa5061f5f3d7679c48L160-R162)

**Configuration and test updates for scale-out HSR:**

* The `constants.yaml` configuration is updated to use the correct key `scale_out_hsr` (was previously `angi_scale_out_hsr`) for the `migration-threshold` property.
* The test database in `get_pcmk_properties_db_test.py` adds an entry for `scale_out_hsr` with the correct `migration-threshold` value and required status.
* A new test is added to verify that the migration threshold for scale-out HSR is resolved correctly to `["50"]` and is required.