### PR TITLE
Pin GitHub Actions by SHA and Docker images by digest

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -14,6 +14,9 @@ on:
       - 'development-*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: sap-automation-qa
 
@@ -26,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Check ACR configuration
         id: acr-check
@@ -47,7 +50,7 @@ jobs:
 
       - name: Azure Login (MSI/OIDC)
         if: steps.acr-check.outputs.acr_configured == 'true'
-        uses: azure/login@v2
+        uses: azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -60,7 +63,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
         with:
           images: ${{ secrets.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}
           tags: |
@@ -71,7 +74,7 @@ jobs:
 
       - name: Build Docker image (validation only)
         if: steps.acr-check.outputs.acr_configured == 'false'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./deploy/Dockerfile
@@ -91,7 +94,7 @@ jobs:
 
       - name: Build and push Docker image to ACR
         if: steps.acr-check.outputs.acr_configured == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./deploy/Dockerfile

--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Collect traffic stats
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Stage 1: Build stage — resolve and install deps for Python 3.12
-FROM mcr.microsoft.com/azurelinux/base/python:3.12 AS builder
+FROM mcr.microsoft.com/azurelinux/base/python:3.12@sha256:8300706a0e644a7e260b6a464a1ae3967181ee9057a4accceaaf0ecdedb1d4a2 AS builder
 WORKDIR /build
 RUN tdnf update -y && tdnf install -y \
     gcc \
@@ -17,7 +17,7 @@ RUN python3 -m venv /opt/venv \
     && pip install --no-cache-dir -r requirements.lock
 
 # Stage 2: Startup stage
-FROM mcr.microsoft.com/azurelinux/base/python:3.12
+FROM mcr.microsoft.com/azurelinux/base/python:3.12@sha256:8300706a0e644a7e260b6a464a1ae3967181ee9057a4accceaaf0ecdedb1d4a2
 
 RUN tdnf update -y && tdnf install -y \
     openssh-clients \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,9 +28,17 @@ _setup_local_env() {
     if ! command_exists az; then
 		log "INFO" "Azure CLI not found. Installing Azure CLI..."
 		if [[ "${DISTRO_FAMILY:-}" == "debian" ]]; then
-			curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+			local az_install_script
+			az_install_script="$(mktemp)"
+			curl -sL https://aka.ms/InstallAzureCLIDeb -o "$az_install_script"
+			sudo bash "$az_install_script"
+			rm -f "$az_install_script"
 		else
-			curl -sL https://aka.ms/InstallAzureCli | bash
+			local az_install_script
+			az_install_script="$(mktemp)"
+			curl -sL https://aka.ms/InstallAzureCli -o "$az_install_script"
+			bash "$az_install_script"
+			rm -f "$az_install_script"
 		fi
 		if command_exists az; then
 			log "INFO" "Azure CLI installed successfully."


### PR DESCRIPTION
## Summary

Addresses OSSF Scorecard / Pinned-Dependencies findings from PR #245.

## Changes

### GitHub Actions (pinned by commit SHA)
| Action | Version | File(s) |
|--------|---------|---------|
| `actions/checkout` | v4.3.1 | docker-build-push.yml |
| `docker/setup-buildx-action` | v3.9.0 | docker-build-push.yml |
| `azure/login` | v2.3.0 | docker-build-push.yml |
| `docker/metadata-action` | v5.9.0 | docker-build-push.yml |
| `docker/build-push-action` | v5.4.0 | docker-build-push.yml |
| `actions/github-script` | v7.1.0 | traffic-stats.yml |

### Workflow permissions
- Added top-level `permissions: contents: read` to `docker-build-push.yml` (Token-Permissions finding)

### Docker image pinning
- Pinned `mcr.microsoft.com/azurelinux/base/python:3.12` by `@sha256` digest in both Dockerfile stages

### Script hardening
- Replaced `curl | bash` pattern with download-then-run in `scripts/setup.sh` for Azure CLI install (downloadThenRun finding)

## Testing
- All 748 unit tests pass with 85.25% coverage