### PR TITLE
Skip Azure OIDC login on pull requests in Docker workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Azure Login (MSI/OIDC)
-        if: steps.acr-check.outputs.acr_configured == 'true'
+        if: steps.acr-check.outputs.acr_configured == 'true' && github.event_name != 'pull_request'
         uses: azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -57,7 +57,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Login to Azure Container Registry
-        if: steps.acr-check.outputs.acr_configured == 'true'
+        if: steps.acr-check.outputs.acr_configured == 'true' && github.event_name != 'pull_request'
         run: |
           az acr login --name ${{ secrets.ACR_NAME }}
 
@@ -73,7 +73,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Docker image (validation only)
-        if: steps.acr-check.outputs.acr_configured == 'false'
+        if: steps.acr-check.outputs.acr_configured == 'false' || github.event_name == 'pull_request'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
@@ -85,7 +85,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Validate Docker image
-        if: steps.acr-check.outputs.acr_configured == 'false'
+        if: steps.acr-check.outputs.acr_configured == 'false' || github.event_name == 'pull_request'
         run: |
           echo "Validating Docker image..."
           docker images ${{ env.IMAGE_NAME }}:validation
@@ -93,7 +93,7 @@ jobs:
           echo "Docker image validation successful"
 
       - name: Build and push Docker image to ACR
-        if: steps.acr-check.outputs.acr_configured == 'true'
+        if: steps.acr-check.outputs.acr_configured == 'true' && github.event_name != 'pull_request'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .


### PR DESCRIPTION
## Summary

Fixes the `build-and-push` CI failure on PR #245 caused by OIDC federated identity not matching `pull_request` subject claims.

## Problem

The Azure AD federated credential is configured for branch pushes but not for PR events. When the Docker workflow runs on a PR, Azure Login fails with:
```
AADSTS700213: No matching federated identity record found for presented assertion subject
'repository_owner_id:...:pull_request'
```

## Fix

- **Azure Login + ACR Login** — skipped on PRs (not needed since PRs never push images)
- **Build path** — PRs now always use the validation-only path (build + smoke test, no push)
- **ACR build-push** — additionally gated on `github.event_name != 'pull_request'`

Push events continue to authenticate and push to ACR as before.