### PR TITLE
Add symbolic links for skills and setup guide in the .gemini and skil…

### DIFF
--- a/.gemini/skills/setup-guide
+++ b/.gemini/skills/setup-guide
@@ -1,0 +1,1 @@
+../../.github/skills/setup-guide

--- a/.gemini/skills/test-result-analyzer
+++ b/.gemini/skills/test-result-analyzer
@@ -1,0 +1,1 @@
+../../.github/skills/test-result-analyzer

--- a/.gemini/skills/test-runner
+++ b/.gemini/skills/test-runner
@@ -1,0 +1,1 @@
+../../.github/skills/test-runner

--- a/.gemini/skills/workspace-creator
+++ b/.gemini/skills/workspace-creator
@@ -1,0 +1,1 @@
+../../.github/skills/workspace-creator

--- a/.gemini/skills/workspace-validator
+++ b/.gemini/skills/workspace-validator
@@ -1,0 +1,1 @@
+../../.github/skills/workspace-validator

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/skills/setup-guide
+++ b/skills/setup-guide
@@ -1,0 +1,1 @@
+../.github/skills/setup-guide

--- a/skills/test-result-analyzer
+++ b/skills/test-result-analyzer
@@ -1,0 +1,1 @@
+../.github/skills/test-result-analyzer

--- a/skills/test-runner
+++ b/skills/test-runner
@@ -1,0 +1,1 @@
+../.github/skills/test-runner

--- a/skills/workspace-creator
+++ b/skills/workspace-creator
@@ -1,0 +1,1 @@
+../.github/skills/workspace-creator

--- a/skills/workspace-validator
+++ b/skills/workspace-validator
@@ -1,0 +1,1 @@
+../.github/skills/workspace-validator


### PR DESCRIPTION
This pull request adds symlinks for several skill-related files in both the `.gemini/skills` and `skills` directories, pointing them to their respective locations in the `.github/skills` directory. It also adds a reference to a Copilot instructions file in `GEMINI.md`. These changes help standardize skill file locations and documentation references.

Symlink additions for skills:

* Added symlinks in `.gemini/skills` for `setup-guide`, `test-result-analyzer`, `test-runner`, `workspace-creator`, and `workspace-validator`, each pointing to the corresponding file in `.github/skills`. [[1]](diffhunk://#diff-85bf327da473d92a472e262f6afd60304bbae477ab8ff90f951ab615b110f5a4R1) [[2]](diffhunk://#diff-3a1892a7a5b7bdc8f144387f4317040fa8463d0e4b9418655c4312977c03e48bR1) [[3]](diffhunk://#diff-06c86dc028e7429896ed6f4a4eedfe5ae119727c12b0a117521116e9a4dd32efR1) [[4]](diffhunk://#diff-aa18e87e380caea658b6004aaf17130e789310c5710d65a0bbbcad7691564a76R1) [[5]](diffhunk://#diff-6bab97caf02d99946680959c16ad99d9f693950bae0c732e21f1d6fdbb81c34bR1)
* Added symlinks in `skills` for the same set of skill files, pointing to `.github/skills`. [[1]](diffhunk://#diff-c568adcd243a56a8c6c0ead901822a75c46d0d62cbd0cac981803d58ff016973R1) [[2]](diffhunk://#diff-7caed3c8e2e8654010c5574fda73cca783d1b27faad872120eb7903006859df8R1) [[3]](diffhunk://#diff-c45871f441ce34239501a8a95031f90d3aed13f368c0d703d25eeb483cea6f14R1) [[4]](diffhunk://#diff-686a2658abb90c50eac80723db0a43e50f3dcd7e34e12ace746bdebdd74a35c0R1) [[5]](diffhunk://#diff-94b61c05f7dcae3355f444ca7eeed9f7a0820e17ddbf84dc1dd268c5dc80d102R1)

Documentation update:

* Added a reference to `.github/copilot-instructions.md` in `GEMINI.md` for improved documentation.