### PR TITLE
Add label verification step to GitHub Actions workflow for pull requests

### DIFF
--- a/.github/workflows/github-actions-code-coverage.yml
+++ b/.github/workflows/github-actions-code-coverage.yml
@@ -1,10 +1,32 @@
 
 name: Pull Request - Code Coverage
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 permissions:
   contents: read
 
 jobs:
+  check-labels:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
+        with:
+          egress-policy: audit
+
+      - name: Verify PR has at least one label
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          if [ -z "$PR_LABELS" ]; then
+            echo "::error::PR must have at least one label before merging."
+            exit 1
+          fi
+          echo "Labels found: $PR_LABELS"
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/github-actions-code-coverage.yml
+++ b/.github/workflows/github-actions-code-coverage.yml
@@ -2,6 +2,7 @@
 name: Pull Request - Code Coverage
 on:
   push:
+    branches: [main, development-*]
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 permissions:

--- a/.github/workflows/github-actions-code-coverage.yml
+++ b/.github/workflows/github-actions-code-coverage.yml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   check-labels:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -18,6 +17,7 @@ jobs:
           egress-policy: audit
 
       - name: Verify PR has at least one label
+        if: github.event_name == 'pull_request'
         env:
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
@@ -28,6 +28,7 @@ jobs:
           echo "Labels found: $PR_LABELS"
 
   build:
+    needs: check-labels
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/monitor-sap-docs.yml
+++ b/.github/workflows/monitor-sap-docs.yml
@@ -2,7 +2,7 @@ name: Monitor SAP Documentation Changes
 
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -25,27 +25,19 @@ jobs:
             api.github.com:443
             github.com:443
 
-      - name: Validate PAT is configured
-        env:
-          HAS_PAT: ${{ secrets.AZURE_DOCS_PAT != '' }}
-        run: |
-          if [ "$HAS_PAT" != "true" ]; then
-            echo "::error::AZURE_DOCS_PAT secret is not configured."
-            exit 1
-          fi
-
       - name: Fetch recent SAP doc changes
         id: check
         env:
-          GH_TOKEN: ${{ secrets.AZURE_DOCS_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
-          SINCE=$(date -u -d '12 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          SINCE=$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "Checking commits since ${SINCE} in articles/sap/workloads/"
 
-          # Fetch commits; cap at 50 to bound API calls and output size
-          COMMITS_JSON=$(gh api "repos/MicrosoftDocs/azure-docs-pr/commits" \
+          # Fetch commits; --method GET required (gh defaults to POST with -f)
+          COMMITS_JSON=$(gh api "repos/MicrosoftDocs/azure-docs/commits" \
+            --method GET \
             -f since="$SINCE" \
             -f path="articles/sap/workloads" \
             -f per_page=50 \
@@ -76,7 +68,7 @@ jobs:
             echo "## SAP Documentation Changes Detected"
             echo ""
             echo "**${COUNT}** commit(s) modified files under \`articles/sap/workloads/\` in"
-            echo "[MicrosoftDocs/azure-docs-pr](https://github.com/MicrosoftDocs/azure-docs-pr)."
+            echo "[MicrosoftDocs/azure-docs](https://github.com/MicrosoftDocs/azure-docs)."
             echo ""
             echo "### Commits"
             echo ""
@@ -108,7 +100,8 @@ jobs:
               echo "- _(additional commits truncated)_" >> "$BODY_FILE"
               break
             fi
-            gh api "repos/MicrosoftDocs/azure-docs-pr/commits/${SHA}" \
+            gh api "repos/MicrosoftDocs/azure-docs/commits/${SHA}" \
+              --method GET \
               --jq '.files[]? | select(.filename | startswith("articles/sap/workloads/")) | "- `\(.filename)` (\(.status))"' \
               >> "$BODY_FILE" || true
             PROCESSED=$((PROCESSED + 1))
@@ -138,7 +131,7 @@ jobs:
           # Ensure the label exists
           gh label create "sap-docs-update" \
             --repo "$REPO" \
-            --description "SAP documentation change detected in azure-docs-pr" \
+            --description "SAP documentation change detected in azure-docs" \
             --color "0075ca" 2>/dev/null || true
 
           # Check for existing open issue to avoid duplicates

--- a/.github/workflows/monitor-sap-docs.yml
+++ b/.github/workflows/monitor-sap-docs.yml
@@ -1,0 +1,176 @@
+name: Monitor SAP Documentation Changes
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: monitor-sap-docs
+  cancel-in-progress: false
+
+jobs:
+  check-sap-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      - name: Validate PAT is configured
+        env:
+          HAS_PAT: ${{ secrets.AZURE_DOCS_PAT != '' }}
+        run: |
+          if [ "$HAS_PAT" != "true" ]; then
+            echo "::error::AZURE_DOCS_PAT secret is not configured."
+            exit 1
+          fi
+
+      - name: Fetch recent SAP doc changes
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.AZURE_DOCS_PAT }}
+        run: |
+          set -euo pipefail
+
+          SINCE=$(date -u -d '12 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          echo "Checking commits since ${SINCE} in articles/sap/workloads/"
+
+          # Fetch commits; cap at 50 to bound API calls and output size
+          COMMITS_JSON=$(gh api "repos/MicrosoftDocs/azure-docs-pr/commits" \
+            -f since="$SINCE" \
+            -f path="articles/sap/workloads" \
+            -f per_page=50 \
+            --jq '.')
+
+          COUNT=$(echo "$COMMITS_JSON" | jq 'length')
+
+          # Validate response is a JSON array (API errors return objects)
+          if ! echo "$COMMITS_JSON" | jq -e 'type == "array"' > /dev/null 2>&1; then
+            echo "::error::Unexpected API response (expected array, got object)."
+            exit 1
+          fi
+
+          echo "Found ${COUNT} commit(s) touching articles/sap/workloads/"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+          # Write body to a temp file (avoids delimiter injection and shell expansion)
+          BODY_FILE=$(mktemp)
+          echo "body_file=${BODY_FILE}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## SAP Documentation Changes Detected"
+            echo ""
+            echo "**${COUNT}** commit(s) modified files under \`articles/sap/workloads/\` in"
+            echo "[MicrosoftDocs/azure-docs-pr](https://github.com/MicrosoftDocs/azure-docs-pr)."
+            echo ""
+            echo "### Commits"
+            echo ""
+            echo "| SHA | Message | Author | Date |"
+            echo "|-----|---------|--------|------|"
+          } > "$BODY_FILE"
+
+          # Build commit table rows — sanitize messages and author names
+          # Strip control chars and escape pipe characters to prevent Markdown table breakage
+          echo "$COMMITS_JSON" | jq -r '.[] |
+            .sha[0:7] as $sha |
+            (.commit.message | split("\n")[0] | gsub("[\\x00-\\x1f\\x7f]"; "") | gsub("\\|"; "∣") | if length > 80 then .[0:80] + "…" else . end) as $msg |
+            (.commit.author.name | gsub("[\\x00-\\x1f\\x7f]"; "") | gsub("\\|"; "∣")) as $author |
+            .commit.author.date[0:10] as $date |
+            "| \($sha) | \($msg) | \($author) | \($date) |"' >> "$BODY_FILE"
+
+          echo "" >> "$BODY_FILE"
+          echo "### Changed Files" >> "$BODY_FILE"
+          echo "" >> "$BODY_FILE"
+
+          # Fetch per-commit file lists; validate SHA format before using in URL
+          PROCESSED=0
+          for SHA in $(echo "$COMMITS_JSON" | jq -r '.[].sha'); do
+            if ! echo "$SHA" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "::warning::Skipping invalid SHA: ${SHA:0:12}..."
+              continue
+            fi
+            if [ "$PROCESSED" -ge 20 ]; then
+              echo "- _(additional commits truncated)_" >> "$BODY_FILE"
+              break
+            fi
+            gh api "repos/MicrosoftDocs/azure-docs-pr/commits/${SHA}" \
+              --jq '.files[]? | select(.filename | startswith("articles/sap/workloads/")) | "- `\(.filename)` (\(.status))"' \
+              >> "$BODY_FILE" || true
+            PROCESSED=$((PROCESSED + 1))
+          done
+
+          {
+            echo ""
+            echo "---"
+            echo "> Review these changes for potential impact on STAF configuration checks,"
+            echo "> HA test scenarios, or documentation references."
+          } >> "$BODY_FILE"
+
+      - name: Create or update tracking issue
+        if: steps.check.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY_FILE: ${{ steps.check.outputs.body_file }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Append workflow link to body file
+          echo "" >> "$BODY_FILE"
+          echo "*Auto-generated by [monitor-sap-docs](${WORKFLOW_URL}) workflow.*" >> "$BODY_FILE"
+
+          # Ensure the label exists
+          gh label create "sap-docs-update" \
+            --repo "$REPO" \
+            --description "SAP documentation change detected in azure-docs-pr" \
+            --color "0075ca" 2>/dev/null || true
+
+          # Check for existing open issue to avoid duplicates
+          EXISTING_NUM=$(gh issue list \
+            --repo "$REPO" \
+            --label "sap-docs-update" \
+            --state open \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
+
+          TITLE="SAP Documentation Changes Detected - $(date -u +%Y-%m-%d)"
+
+          if [ -n "$EXISTING_NUM" ]; then
+            echo "Appending to existing issue #${EXISTING_NUM}"
+            gh issue comment "$EXISTING_NUM" \
+              --repo "$REPO" \
+              --body-file "$BODY_FILE"
+          else
+            echo "Creating new tracking issue"
+            gh issue create \
+              --repo "$REPO" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "sap-docs-update"
+          fi
+
+      - name: Cleanup temp files
+        if: always()
+        env:
+          BODY_FILE: ${{ steps.check.outputs.body_file }}
+        run: |
+          if [ -n "${BODY_FILE:-}" ] && [ -f "$BODY_FILE" ]; then
+            rm -f "$BODY_FILE"
+          fi


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for code coverage to enforce that every pull request has at least one label before it can be merged. It introduces a new job to check for labels and hardens the runner for improved security.

**Workflow enforcement and security improvements:**

* Added a `check-labels` job to `.github/workflows/github-actions-code-coverage.yml` that verifies pull requests have at least one label before merging, and provides an error if none are present.
* Integrated the `step-security/harden-runner` action to audit outbound network connections for enhanced security during workflow runs.
* Updated the workflow trigger for `pull_request` events to include specific types: `opened`, `synchronize`, `reopened`, `labeled`, and `unlabeled`, ensuring label checks are performed when relevant events occur.