### PR TITLE
Update timeout values in resource defaults to 120 seconds

### DIFF
--- a/src/roles/ha_db_hana/tasks/files/constants.yaml
+++ b/src/roles/ha_db_hana/tasks/files/constants.yaml
@@ -183,7 +183,7 @@ RESOURCE_DEFAULTS:
             value:                  ["600", "600s"]
             required:               false
           timeout:
-            value:                  ["15", "15s"]
+            value:                  ["120", "120s"]
             required:               false
 
     topology:
@@ -719,7 +719,7 @@ RESOURCE_DEFAULTS:
             value:                  ["600", "600s"]
             required:               false
           timeout:
-            value:                  ["15", "15s"]
+            value:                  ["120", "120s"]
             required:               false
 
     topology:

--- a/src/roles/ha_scs/tasks/files/constants.yaml
+++ b/src/roles/ha_scs/tasks/files/constants.yaml
@@ -192,7 +192,7 @@ RESOURCE_DEFAULTS:
             value:                  ["600", "600s"]
             required:               false
           timeout:
-            value:                  ["15", "15s"]
+            value:                  ["120", "120s"]
             required:               false
 
     ascs:
@@ -481,7 +481,7 @@ RESOURCE_DEFAULTS:
             value:                  "600"
             required:               false
           timeout:
-            value:                  ["15", "15s"]
+            value:                  ["120", "120s"]
             required:               false
 
     ascs:


### PR DESCRIPTION
This pull request increases the default timeout values for certain resource operations in both the `ha_db_hana` and `ha_scs` roles. The timeout for these operations has been changed from 15 seconds to 120 seconds, which should help prevent premature failures during longer-running tasks.

https://github.com/MicrosoftDocs/azure-docs-pr/pull/316652

Timeout configuration updates:

* Increased the default `timeout` value for resource operations from `["15", "15s"]` to `["120", "120s"]` in two places within `src/roles/ha_db_hana/tasks/files/constants.yaml`. [[1]](diffhunk://#diff-093f5d6748402718d93defe0a6f158f9af040713804dced684a2f3cd4a5cd3c0L186-R186) [[2]](diffhunk://#diff-093f5d6748402718d93defe0a6f158f9af040713804dced684a2f3cd4a5cd3c0L722-R722)
* Increased the default `timeout` value for resource operations from `["15", "15s"]` to `["120", "120s"]` in two places within `src/roles/ha_scs/tasks/files/constants.yaml`. [[1]](diffhunk://#diff-9468267d6716aa3f4daa87223fa1cbc39313abd068ab270111d0a815eede5781L195-R195) [[2]](diffhunk://#diff-9468267d6716aa3f4daa87223fa1cbc39313abd068ab270111d0a815eede5781L484-R484)