### PR TITLE
Refactor IMDS metadata handling and improve error messaging

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -43,7 +43,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build Docker image (validation only)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -87,7 +87,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/release-docs-sync.yml
+++ b/.github/workflows/release-docs-sync.yml
@@ -181,7 +181,7 @@ jobs:
             || git checkout -q --detach "refs/tags/${HEAD_REF}" 2>/dev/null || true
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # Ansible packages
-ansible-core
+ansible-core==2.16.19
 ansible-lint
 ansible-runner
 
@@ -40,7 +40,7 @@ pywinrm[credssp]
 cryptography>=48.0.1
 
 # CLI tools
-click
+click>=8.3.3
 rich
 # API 
 fastapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ ansible-compat==26.3.0 \
     --hash=sha256:15f0ea5ff6fcc5587b6b11a4a436fdeefd0fd4a46afe92d4e483c28370082ae0 \
     --hash=sha256:4fb48f324383033cf24df5ccb63bca4da766cb4ebbd4bc9dbad91b108f512a73
     # via ansible-lint
-ansible-core==2.17.14 \
-    --hash=sha256:34a49582a57c2f2af17ede2cefd3b3602a2d55d22089f3928570d52030cafa35 \
-    --hash=sha256:7c17fee39f8c29d70e3282a7e9c10bd70d5cd4fd13ddffc5dcaa52adbd142ff8
+ansible-core==2.16.19 \
+    --hash=sha256:5125f26412039ffb99a3a7723618535ab80e6ef38944aa2453997350388f4ef4 \
+    --hash=sha256:d7a32ba0f96f9c6582b7ff159a4a6f0e694662cfc4840497c88fed63bf58cd14
     # via
     #   -r requirements.in
     #   ansible-compat
@@ -393,9 +393,9 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
-click==8.3.2 \
-    --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
-    --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+click==8.4.2 \
+    --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
     # via
     #   -r requirements.in
     #   black

--- a/src/roles/configuration_checks/tasks/main.yml
+++ b/src/roles/configuration_checks/tasks/main.yml
@@ -267,6 +267,7 @@
       when:                         ansible_os_family == "Windows"
 
     - name:                         "{{ check_type.name }} - Select command check results for host OS"
+      no_log:                       true
       ansible.builtin.set_fact:
         command_check_results: >-
                                         {{ windows_command_check_results
@@ -274,6 +275,7 @@
                                            else linux_command_check_results }}
   rescue:
     - name:                         Preserve command check failure result
+      no_log:                       true
       ansible.builtin.set_fact:
         command_check_results:      "{{ ansible_failed_result }}"
 
@@ -368,6 +370,7 @@
       when:                         ansible_os_family == "Windows"
 
     - name:                         "{{ check_type.name }} - Select module check results for host OS"
+      no_log:                       true
       ansible.builtin.set_fact:
         module_check_results: >-
                                         {{ windows_module_check_results
@@ -375,6 +378,7 @@
                                            else linux_module_check_results }}
   rescue:
     - name:                         Preserve module check failure result
+      no_log:                       true
       ansible.builtin.set_fact:
         module_check_results:       "{{ ansible_failed_result }}"
 

--- a/src/roles/configuration_checks/tasks/main.yml
+++ b/src/roles/configuration_checks/tasks/main.yml
@@ -13,10 +13,10 @@
     headers:
       Metadata:                     true
     timeout:                        10
-  register:                         compute_metadata
+  register:                         linux_compute_metadata
   retries:                          3
   delay:                            2
-  until:                            compute_metadata is not failed
+  until:                            linux_compute_metadata is not failed
   failed_when:                      false
   when:                             ansible_os_family != "Windows"
 
@@ -28,12 +28,19 @@
       Metadata:                     true
     return_content:                 true
     timeout:                        10
-  register:                         compute_metadata
+  register:                         windows_compute_metadata
   retries:                          3
   delay:                            2
-  until:                            compute_metadata is not failed
+  until:                            windows_compute_metadata is not failed
   failed_when:                      false
   when:                             ansible_os_family == "Windows"
+
+- name:                             "{{ check_type.name }} - Select IMDS response for host OS"
+  ansible.builtin.set_fact:
+    compute_metadata: >-
+                                    {{ windows_compute_metadata
+                                       if ansible_os_family == 'Windows'
+                                       else linux_compute_metadata }}
 
 - name:                             "{{ check_type.name }} - Normalize Windows IMDS response"
   ansible.builtin.set_fact:
@@ -169,6 +176,13 @@
     module_checks_yaml:             "{{ {'checks': module_checks} | to_yaml }}"
   when:                             command_checks is defined or azure_checks is defined or module_checks is defined
 
+- name:                             "{{ check_type.name }} - Initialize collector results"
+  no_log:                           true
+  ansible.builtin.set_fact:
+    command_check_results:          {}
+    azure_check_results:            {}
+    module_check_results:           {}
+
 - name:                             "{{ check_type.name }} - Run Windows command-based collectors"
   no_log:                           true
   ansible.windows.win_shell:        "{{ item.collector_args.windows_command | default(item.collector_args.command) }}"
@@ -231,7 +245,7 @@
         parallel_execution:         true
         max_workers:                1
         enable_retry:               true
-      register:                     command_check_results
+      register:                     linux_command_check_results
       when:                         ansible_os_family != "Windows"
 
     - name:                         "{{ check_type.name }} - Evaluate Windows command-based configuration checks"
@@ -249,12 +263,21 @@
         parallel_execution:         true
         max_workers:                1
         enable_retry:               true
-      register:                     command_check_results
+      register:                     windows_command_check_results
       when:                         ansible_os_family == "Windows"
+
+    - name:                         "{{ check_type.name }} - Select command check results for host OS"
+      ansible.builtin.set_fact:
+        command_check_results: >-
+                                        {{ windows_command_check_results
+                                           if ansible_os_family == 'Windows'
+                                           else linux_command_check_results }}
   rescue:
     - name:                         Log command check failure
       ansible.builtin.debug:
-        msg:                        "Command-based configuration checks failed {{ command_check_results.msg }}"
+        msg: >-
+                                        Command-based configuration checks failed
+                                        {{ ansible_failed_result.msg | default('Unknown error') }}
 
 - name:                             "{{ check_type.name }} - Debug the logs from command-based configuration check"
   when:
@@ -319,7 +342,7 @@
         parallel_execution:         true
         max_workers:                1
         enable_retry:               true
-      register:                     module_check_results
+      register:                     linux_module_check_results
       when:                         ansible_os_family != "Windows"
 
     - name:                         Evaluate Windows module-based configuration checks
@@ -337,12 +360,21 @@
         parallel_execution:         true
         max_workers:                1
         enable_retry:               true
-      register:                     module_check_results
+      register:                     windows_module_check_results
       when:                         ansible_os_family == "Windows"
+
+    - name:                         "{{ check_type.name }} - Select module check results for host OS"
+      ansible.builtin.set_fact:
+        module_check_results: >-
+                                        {{ windows_module_check_results
+                                           if ansible_os_family == 'Windows'
+                                           else linux_module_check_results }}
   rescue:
     - name:                         Log module check failure
       ansible.builtin.debug:
-        msg:                        "Module-based configuration checks failed but continuing {{ module_check_results.msg }}"
+        msg: >-
+                                        Module-based configuration checks failed but continuing
+                                        {{ ansible_failed_result.msg | default('Unknown error') }}
 
 - name:                             "{{ check_type.name }} - Debug the logs from module-based configuration check"
   when:

--- a/src/roles/configuration_checks/tasks/main.yml
+++ b/src/roles/configuration_checks/tasks/main.yml
@@ -273,6 +273,10 @@
                                            if ansible_os_family == 'Windows'
                                            else linux_command_check_results }}
   rescue:
+    - name:                         Preserve command check failure result
+      ansible.builtin.set_fact:
+        command_check_results:      "{{ ansible_failed_result }}"
+
     - name:                         Log command check failure
       ansible.builtin.debug:
         msg: >-
@@ -370,6 +374,10 @@
                                            if ansible_os_family == 'Windows'
                                            else linux_module_check_results }}
   rescue:
+    - name:                         Preserve module check failure result
+      ansible.builtin.set_fact:
+        module_check_results:       "{{ ansible_failed_result }}"
+
     - name:                         Log module check failure
       ansible.builtin.debug:
         msg: >-


### PR DESCRIPTION
This pull request refactors the handling of OS-specific facts and results in the `configuration_checks` role to improve clarity and reliability. The main changes involve separating Linux and Windows variables for metadata and check results, then unifying them into common variables for downstream tasks. This helps prevent variable overwrites and makes the playbook logic more robust and easier to maintain.

**Refactoring for OS-specific result management:**

* Separate variables are now used for Linux and Windows compute metadata (`linux_compute_metadata`, `windows_compute_metadata`), which are then unified into `compute_metadata` based on the host OS. [[1]](diffhunk://#diff-a08fa6f2933e5f29641702425a601cbdde957628f22e0241c34470d1d413f3b9L16-R19) [[2]](diffhunk://#diff-a08fa6f2933e5f29641702425a601cbdde957628f22e0241c34470d1d413f3b9L31-R44)
* Command-based and module-based check results are now registered separately for Linux and Windows (`linux_command_check_results`, `windows_command_check_results`, `linux_module_check_results`, `windows_module_check_results`), and then combined into unified variables (`command_check_results`, `module_check_results`) using `set_fact`. [[1]](diffhunk://#diff-a08fa6f2933e5f29641702425a601cbdde957628f22e0241c34470d1d413f3b9L234-R248) [[2]](diffhunk://#diff-a08fa6f2933e5f29641702425a601cbdde957628f22e0241c34470d1d413f3b9L252-R280) [[3]](diffhunk://#diff-a08fa6f2933e5f29641702425a601cbdde957628f22e0241c34470d1d413f3b9L322-R345) [[4]](diffhunk://#diff-a08fa6f2933e5f29641702425a601cbdde957628f22e0241c34470d1d413f3b9L340-R377)

**Initialization and error handling improvements:**

* The results dictionaries (`command_check_results`, `azure_check_results`, `module_check_results`) are now explicitly initialized to empty dictionaries before execution, reducing the risk of referencing undefined variables.
* Error messages in rescue blocks now use `ansible_failed_result.msg` with a default value for clearer and more reliable logging. [[1]](diffhunk://#diff-a08fa6f2933e5f29641702425a601cbdde957628f22e0241c34470d1d413f3b9L252-R280) [[2]](diffhunk://#diff-a08fa6f2933e5f29641702425a601cbdde957628f22e0241c34470d1d413f3b9L340-R377)