### PR TITLE
Enhance DB2 user language command validation and error handling

### DIFF
--- a/src/roles/configuration_checks/tasks/files/db2.yml
+++ b/src/roles/configuration_checks/tasks/files/db2.yml
@@ -129,7 +129,16 @@ checks:
       database_type:                    [*db2]
     collector_type:                     *command
     collector_args:
-      command:                          "language=$(locale 2>/dev/null | awk -F= '$1 == \"LANG\" {gsub(/\"/, \"\", $2); print $2}'); [ -n \"$language\" ] && echo \"$language\" || echo \"LANG_NOT_SET\""
+      command: >-
+                                        db2_user=$(ps -eo user=,comm= | awk '$2 == "db2sysc" {print $1; exit}');
+                                        if [ -z "$db2_user" ]; then
+                                          echo "DB2_INSTANCE_OWNER_NOT_FOUND";
+                                        elif ! locale_output=$(su - "$db2_user" -c locale 2>/dev/null); then
+                                          echo "DB2_USER_LOGIN_FAILED";
+                                        else
+                                          language=$(printf '%s\n' "$locale_output" | awk -F= '$1 == "LANG" {gsub(/"/, "", $2); print $2}');
+                                          [ -n "$language" ] && echo "$language" || echo "LANG_NOT_SET";
+                                        fi
       user:                             *root
     validator_type:                     *string
     validator_args:

--- a/src/roles/configuration_checks/tasks/files/db2.yml
+++ b/src/roles/configuration_checks/tasks/files/db2.yml
@@ -129,8 +129,16 @@ checks:
       database_type:                    [*db2]
     collector_type:                     *command
     collector_args:
-      command:                          "echo $LANG"
-      user:                             *db2sid
+      command: >-
+                                        db2_user="db2$(printf '%s' '{{ CONTEXT.database_sid }}' | tr '[:upper:]' '[:lower:]')";
+                                        if ! id "$db2_user" >/dev/null 2>&1; then
+                                          echo "DB2_USER_NOT_FOUND: $db2_user";
+                                        elif ! language=$(su - "$db2_user" -c 'echo "${LANG:-LANG_NOT_SET}"' 2>/dev/null); then
+                                          echo "DB2_USER_LOGIN_FAILED: $db2_user";
+                                        else
+                                          echo "$language";
+                                        fi
+      user:                             *root
     validator_type:                     *string
     validator_args:
       expected_output:                  "en_US.UTF-8"

--- a/src/roles/configuration_checks/tasks/files/db2.yml
+++ b/src/roles/configuration_checks/tasks/files/db2.yml
@@ -129,15 +129,7 @@ checks:
       database_type:                    [*db2]
     collector_type:                     *command
     collector_args:
-      command: >-
-                                        db2_user="db2$(printf '%s' '{{ CONTEXT.database_sid }}' | tr '[:upper:]' '[:lower:]')";
-                                        if ! id "$db2_user" >/dev/null 2>&1; then
-                                          echo "DB2_USER_NOT_FOUND: $db2_user";
-                                        elif ! language=$(su - "$db2_user" -c 'echo "${LANG:-LANG_NOT_SET}"' 2>/dev/null); then
-                                          echo "DB2_USER_LOGIN_FAILED: $db2_user";
-                                        else
-                                          echo "$language";
-                                        fi
+      command:                          "language=$(locale 2>/dev/null | awk -F= '$1 == \"LANG\" {gsub(/\"/, \"\", $2); print $2}'); [ -n \"$language\" ] && echo \"$language\" || echo \"LANG_NOT_SET\""
       user:                             *root
     validator_type:                     *string
     validator_args:

--- a/src/roles/configuration_checks/tasks/files/db2.yml
+++ b/src/roles/configuration_checks/tasks/files/db2.yml
@@ -116,7 +116,7 @@ checks:
 
   - id:                                 "DB-Db2-0002"
     name:                               "Linux installation & system language"
-    description:                        "Check if the Linux installation and system language are supported for Db2"
+    description:                        "Check whether LANG is set to the supported locale for the Db2 instance user"
     category:                           *sap_check
     severity:                           *high
     workload:                           *sap

--- a/src/roles/configuration_checks/tasks/files/db2.yml
+++ b/src/roles/configuration_checks/tasks/files/db2.yml
@@ -129,17 +129,8 @@ checks:
       database_type:                    [*db2]
     collector_type:                     *command
     collector_args:
-      command: >-
-                                        db2_user=$(ps -eo user=,comm= | awk '$2 == "db2sysc" {print $1; exit}');
-                                        if [ -z "$db2_user" ]; then
-                                          echo "DB2_INSTANCE_OWNER_NOT_FOUND";
-                                        elif ! locale_output=$(su - "$db2_user" -c locale 2>/dev/null); then
-                                          echo "DB2_USER_LOGIN_FAILED";
-                                        else
-                                          language=$(printf '%s\n' "$locale_output" | awk -F= '$1 == "LANG" {gsub(/"/, "", $2); print $2}');
-                                          [ -n "$language" ] && echo "$language" || echo "LANG_NOT_SET";
-                                        fi
-      user:                             *root
+      command:                          "language=$(locale 2>/dev/null | awk -F= '$1 == \"LANG\" {gsub(/\"/, \"\", $2); print $2}'); [ -n \"$language\" ] && echo \"$language\" || echo \"LANG_NOT_SET\""
+      user:                             *db2sid
     validator_type:                     *string
     validator_args:
       expected_output:                  "en_US.UTF-8"


### PR DESCRIPTION
This pull request updates the logic for checking the language environment variable for DB2 users in the `db2.yml` configuration check. The new approach is more robust, handling cases where the DB2 user does not exist or cannot log in, and ensures the check is run as `root` instead of the DB2 user.

**Improvements to DB2 language environment check:**

* The command now dynamically constructs the DB2 user name, checks if the user exists, attempts to log in as that user to retrieve the `LANG` environment variable, and provides explicit error messages if the user is missing or login fails.
* The check is now executed as `root` rather than the DB2 user, allowing it to handle user existence and login failures gracefully.